### PR TITLE
dist: Add Sparkle auto-update via SPM and Check for Updates menu item

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-latest
 
     env:
-      DERIVED_DATA: ${{ runner.temp }}/DerivedData
+      SPM_CACHE: $HOME/.spm-cache
 
     steps:
       - name: Checkout
@@ -31,15 +31,15 @@ jobs:
       - name: Generate Xcode project
         run: xcodegen generate
 
-      # Cache DerivedData (includes SPM SourcePackages + built products).
-      - name: Cache DerivedData
+      # Cache Swift Package Manager artifacts.
+      # Falls back to a static suffix when Package.resolved is absent.
+      - name: Cache SwiftPM
         uses: actions/cache@v4
         with:
-          path: ${{ env.DERIVED_DATA }}
-          key: ${{ runner.os }}-deriveddata-${{ github.ref_name }}-${{ github.sha }}
+          path: ${{ env.SPM_CACHE }}
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') || 'no-spm' }}
           restore-keys: |
-            ${{ runner.os }}-deriveddata-${{ github.ref_name }}-
-            ${{ runner.os }}-deriveddata-
+            ${{ runner.os }}-spm-
 
       - name: Build + test (macOS)
         run: |
@@ -49,5 +49,5 @@ jobs:
             -scheme gowi \
             -configuration Debug \
             -destination 'platform=macOS' \
-            -derivedDataPath "${DERIVED_DATA}" \
+            -clonedSourcePackagesDirPath "${SPM_CACHE}" \
             clean test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
 
     env:
       DERIVED_DATA: ${{ runner.temp }}/DerivedData
-      SPM_CACHE: ${{ runner.temp }}/spm
 
     steps:
       - name: Checkout
@@ -29,17 +28,7 @@ jobs:
       - name: Generate Xcode project
         run: xcodegen generate
 
-      # Cache Swift Package Manager artifacts.
-      # Falls back to a static suffix when Package.resolved is absent.
-      - name: Cache SwiftPM
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.SPM_CACHE }}
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') || 'no-spm' }}
-          restore-keys: |
-            ${{ runner.os }}-spm-
-
-      # Cache DerivedData keyed per branch + commit, with broader restore keys.
+      # Cache DerivedData (includes SPM SourcePackages + built products).
       - name: Cache DerivedData
         uses: actions/cache@v4
         with:
@@ -58,5 +47,4 @@ jobs:
             -configuration Debug \
             -destination 'platform=macOS' \
             -derivedDataPath "${DERIVED_DATA}" \
-            -clonedSourcePackagesDirPath "${SPM_CACHE}" \
             clean test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
   push:
     branches: ["**"]
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Cache DerivedData
         uses: actions/cache@v4
         with:
-          path: ${{ env.DERIVED_DATA }}
+          path: ${{ runner.temp }}/DerivedData
           key: ${{ runner.os }}-deriveddata-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-deriveddata-${{ github.ref_name }}-
@@ -47,5 +47,5 @@ jobs:
             -scheme gowi \
             -configuration Debug \
             -destination 'platform=macOS' \
-            -derivedDataPath "${DERIVED_DATA}" \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData" \
             clean test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,9 +13,6 @@ jobs:
   macos-ci:
     runs-on: macos-latest
 
-    env:
-      DERIVED_DATA: ${{ runner.temp }}/DerivedData
-
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   pull_request:
   push:
     branches: ["**"]
-  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: macos-latest
 
     env:
-      SPM_CACHE: $HOME/.spm-cache
+      DERIVED_DATA: ${{ runner.temp }}/DerivedData
 
     steps:
       - name: Checkout
@@ -31,15 +31,15 @@ jobs:
       - name: Generate Xcode project
         run: xcodegen generate
 
-      # Cache Swift Package Manager artifacts.
-      # Falls back to a static suffix when Package.resolved is absent.
-      - name: Cache SwiftPM
+      # Cache DerivedData (includes SPM SourcePackages + built products).
+      - name: Cache DerivedData
         uses: actions/cache@v4
         with:
-          path: ${{ env.SPM_CACHE }}
-          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved') || 'no-spm' }}
+          path: ${{ env.DERIVED_DATA }}
+          key: ${{ runner.os }}-deriveddata-${{ github.ref_name }}-${{ github.sha }}
           restore-keys: |
-            ${{ runner.os }}-spm-
+            ${{ runner.os }}-deriveddata-${{ github.ref_name }}-
+            ${{ runner.os }}-deriveddata-
 
       - name: Build + test (macOS)
         run: |
@@ -49,5 +49,5 @@ jobs:
             -scheme gowi \
             -configuration Debug \
             -destination 'platform=macOS' \
-            -clonedSourcePackagesDirPath "${SPM_CACHE}" \
+            -derivedDataPath "${DERIVED_DATA}" \
             clean test

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -26,5 +26,9 @@
     <string>public.app-category.developer-tools</string>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright © 2026 Lloyd Major.</string>
+    <key>SUFeedURL</key>
+    <string>https://github.com/lwmajor/gowi/releases/latest/download/appcast.xml</string>
+    <key>SUPublicEDKey</key>
+    <string>wnPc2uX2GOXjWdDABSMNBQn6OfUHeNTnWVbfOfUoJsU=</string>
 </dict>
 </plist>

--- a/App/Info.plist
+++ b/App/Info.plist
@@ -30,5 +30,7 @@
     <string>https://github.com/lwmajor/gowi/releases/latest/download/appcast.xml</string>
     <key>SUPublicEDKey</key>
     <string>wnPc2uX2GOXjWdDABSMNBQn6OfUHeNTnWVbfOfUoJsU=</string>
+    <key>SUEnableInstallerLauncherService</key>
+    <true/>
 </dict>
 </plist>

--- a/Sources/Gowi/GowiApp.swift
+++ b/Sources/Gowi/GowiApp.swift
@@ -1,11 +1,13 @@
 import SwiftUI
 import AppKit
+import Sparkle
 
 @main
 struct GowiApp: App {
     @StateObject private var auth: AuthService
     @StateObject private var model: AppModel
     @StateObject private var store: RepoStore
+    private let updaterController: SPUStandardUpdaterController
 
     init() {
         let auth = AuthService()
@@ -13,6 +15,7 @@ struct GowiApp: App {
         _auth = StateObject(wrappedValue: auth)
         _store = StateObject(wrappedValue: store)
         _model = StateObject(wrappedValue: AppModel(auth: auth, store: store))
+        updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
     }
 
     var body: some Scene {
@@ -24,6 +27,13 @@ struct GowiApp: App {
                 .frame(minWidth: 360, minHeight: 420)
         }
         .defaultSize(width: 480, height: 640)
+        .commands {
+            CommandGroup(after: .appInfo) {
+                Button("Check for Updates…") {
+                    updaterController.updater.checkForUpdates()
+                }
+            }
+        }
 
         Settings {
             SettingsView()

--- a/project.yml
+++ b/project.yml
@@ -10,6 +10,11 @@ configs:
   Debug: debug
   Release: release
 
+packages:
+  Sparkle:
+    url: https://github.com/sparkle-project/Sparkle
+    from: "2.0.0"
+
 settings:
   base:
     SWIFT_VERSION: "5.9"
@@ -25,6 +30,9 @@ targets:
     deploymentTarget: "14.0"
     sources:
       - path: Sources/Gowi
+    dependencies:
+      - package: Sparkle
+        product: Sparkle
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.lloydmajor.gowi


### PR DESCRIPTION
## Summary
- Adds Sparkle as an SPM dependency in `project.yml`
- Configures `SUFeedURL` (GitHub releases latest) and `SUPublicEDKey` in `Info.plist`
- Wires `SPUStandardUpdaterController` into `GowiApp.init()`
- Adds "Check for Updates…" to the app menu via `CommandGroup(after: .appInfo)`

## Notes
The EdDSA public key in `Info.plist` was generated with Sparkle's `generate_keys` tool; the private key is stored securely outside the repo.

After pulling, run `xcodegen generate` then open in Xcode — SPM will fetch Sparkle automatically.

Closes #10, #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)