### PR TITLE
dist: Add build-dmg.sh script

### DIFF
--- a/scripts/build-dmg.sh
+++ b/scripts/build-dmg.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Build a notarized, signed DMG for distribution.
+#
+# Usage: scripts/build-dmg.sh
+#
+# Required env vars (passed through to notarize.sh):
+#   APPLE_ID, APPLE_TEAM_ID, APPLE_APP_PASSWORD — notarization credentials
+#   DEVELOPER_ID — your signing identity, e.g. "Developer ID Application: Your Name (TEAMID)"
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="$REPO_ROOT/build"
+VERSION=$(defaults read "$REPO_ROOT/App/Info.plist" CFBundleShortVersionString 2>/dev/null || grep MARKETING_VERSION "$REPO_ROOT/project.yml" | head -1 | tr -d ' "' | cut -d: -f2)
+DMG_NAME="gowi-${VERSION}.dmg"
+
+: "${DEVELOPER_ID:?Set DEVELOPER_ID to your signing identity}"
+
+mkdir -p "$BUILD_DIR"
+
+echo "Regenerating Xcode project..."
+xcodegen generate --spec "$REPO_ROOT/project.yml"
+
+echo "Building Release..."
+xcodebuild -scheme gowi \
+    -destination 'platform=macOS' \
+    -configuration Release \
+    SYMROOT="$BUILD_DIR" \
+    build
+
+APP="$BUILD_DIR/Release/gowi.app"
+if [[ ! -d "$APP" ]]; then
+    echo "ERROR: built app not found at $APP" >&2
+    exit 1
+fi
+
+echo "Notarizing app..."
+"$SCRIPT_DIR/notarize.sh" "$APP"
+
+echo "Creating DMG..."
+STAGING=$(mktemp -d)
+cp -R "$APP" "$STAGING/gowi.app"
+ln -s /Applications "$STAGING/Applications"
+
+hdiutil create \
+    -volname "gowi" \
+    -srcfolder "$STAGING" \
+    -ov \
+    -format UDZO \
+    "$BUILD_DIR/$DMG_NAME"
+
+rm -rf "$STAGING"
+
+echo "Signing DMG..."
+codesign --sign "$DEVELOPER_ID" \
+    --timestamp \
+    "$BUILD_DIR/$DMG_NAME"
+
+echo "DMG ready: $BUILD_DIR/$DMG_NAME"
+echo ""
+echo "Next: sign the DMG for Sparkle and update appcast.xml:"
+echo "  .build/checkouts/Sparkle/bin/sign_update $BUILD_DIR/$DMG_NAME"


### PR DESCRIPTION
## Summary
- Adds `scripts/build-dmg.sh` to produce a distribution-ready DMG
- Runs `xcodegen generate`, builds Release, notarizes via `scripts/notarize.sh`
- Creates a DMG with an `/Applications` symlink using `hdiutil`
- Signs the DMG with the Developer ID identity from `DEVELOPER_ID` env var
- Prints the `sign_update` command to run for Sparkle signing

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)