### PR TITLE
docs: Update README with install instructions and permissions disclosure

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,30 @@ A lightweight macOS menu bar + window app that shows open pull requests across a
 
 See `pr-tracker-spec.md` for the full product + technical spec and `TASKS.md` for the commit-sized task breakdown.
 
+## Install
+
+1. Download the latest `gowi-x.y.z.dmg` from [Releases](https://github.com/lwmajor/gowi/releases).
+2. Open the DMG and drag **gowi** to `/Applications`.
+3. Launch gowi from `/Applications` or Spotlight.
+4. Click **Sign in with GitHub** and follow the device-flow prompt in your browser.
+5. Open **Settings → Repositories** and add repos in `owner/name` form.
+
+gowi requires macOS 14.0 (Sonoma) or later.
+
+## GitHub permissions
+
+gowi requests one of two OAuth scopes at sign-in:
+
+| Scope | When | Why |
+|---|---|---|
+| `repo` | Default | Read PRs in private repos you have access to. GitHub does not offer a narrower read-only scope for private repos via OAuth. |
+| `public_repo` | If you tick "Public repos only" on the sign-in screen | Read PRs in public repos only. Use this if you only track public repositories. |
+
+gowi is **read-only** — it never opens, closes, merges, or comments on pull requests. No data is sent to any third party; all GitHub communication goes directly to `api.github.com`.
+
 ## Status
 
-Pre-v1. Window app works end-to-end (device-flow sign-in, keychain, settings, per-repo PR fetch, grouped list, status icons, collapsible sections, ⌘R / trackpad pull-to-refresh). MenuBarExtra, cache, Sparkle, and distribution are the remaining milestones.
+Window app is feature-complete for v1: device-flow sign-in, keychain, settings, per-repo PR fetch, batched GraphQL, grouped list, review/CI status icons, new-since dot, collapsible sections, cache, ⌘R / trackpad pull-to-refresh, SAML SSO handling, rate-limit awareness, and menu bar extra. Sparkle auto-update and the distribution pipeline (notarized DMG, appcast) are wired up and ready for the first release.
 
 ## Building
 
@@ -48,10 +69,10 @@ xcodebuild -project gowi.xcodeproj -scheme gowi -destination 'platform=macOS' te
 ```
 App/
   Info.plist
+  appcast.xml             # Sparkle update feed template
   Gowi.entitlements       # sandbox + network.client only
 Sources/Gowi/
-  Config.swift            # OAuth client ID
-  GowiApp.swift           # App entry (scenes)
+  GowiApp.swift           # App entry (scenes + Sparkle updater)
   AppModel.swift          # Observable root state + refresh loop
   Models/                 # PullRequest, TrackedRepo, enums
   Auth/                   # KeychainHelper, DeviceFlowClient, AuthService
@@ -59,5 +80,9 @@ Sources/Gowi/
   Settings/               # RepoStore
   UI/                     # Views
 Tests/GowiTests/          # XCTest — tests compile sources directly
+scripts/
+  notarize.sh             # Submit to Apple notary service and staple
+  build-dmg.sh            # Full release build → notarized DMG
 project.yml               # xcodegen spec
+RELEASING.md              # Step-by-step release process
 ```


### PR DESCRIPTION
## Summary
- Adds **Install** section for end users (download DMG, drag to /Applications, macOS 14+ requirement)
- Adds **GitHub permissions** table explaining `repo` vs `public_repo` scopes and confirming read-only access
- Updates **Status** to reflect v1 feature-complete state
- Updates **Layout** to include `scripts/`, `appcast.xml`, and `RELEASING.md`

Screenshots will be added when the first DMG is cut.

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)