### PR TITLE
polish: simplify main window toolbar to follow Apple HIG

### DIFF
--- a/Sources/Gowi/UI/MainWindow.swift
+++ b/Sources/Gowi/UI/MainWindow.swift
@@ -10,12 +10,19 @@ struct MainWindow: View {
         NavigationStack {
             content
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .navigationTitle(windowTitle)
                 .toolbar { toolbarContent }
         }
         .onAppear { markSeen() }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
             markSeen()
         }
+    }
+
+    private var windowTitle: String {
+        guard auth.state == .signedIn else { return "gowi" }
+        let total = totalPRs(groups)
+        return total > 0 ? "\(total) open" : "gowi"
     }
 
     // MARK: - content
@@ -57,18 +64,7 @@ struct MainWindow: View {
 
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
-        ToolbarItem(placement: .principal) {
-            Image("GowiLogo")
-                .resizable()
-                .scaledToFit()
-                .frame(height: 24)
-        }
         if auth.state == .signedIn {
-            ToolbarItem(placement: .navigation) {
-                Text("\(totalPRs(groups)) open")
-                    .font(.headline)
-                    .monospacedDigit()
-            }
             ToolbarItem(placement: .primaryAction) {
                 Button { model.refresh() } label: {
                     ZStack(alignment: .topTrailing) {


### PR DESCRIPTION
## Summary

- Remove non-standard app logo from the toolbar `.principal` slot — placing the app icon in the toolbar is unusual on macOS and was causing visual clutter
- Remove the duplicate `.navigation`-placement PR count text (was competing with the window title)
- Promote the PR count to the window title via `navigationTitle` (`"1,406 open"` when PRs exist, `"gowi"` otherwise)
- Toolbar now contains only the two action buttons (refresh + settings), consistent with Apple HIG

## Test plan

- [ ] Launch app signed in with tracked repos — title bar shows `N open`, toolbar shows only ↻ and ⚙
- [ ] Launch app with no repos or signed out — title bar shows `gowi`
- [ ] All clear state (0 PRs) — title bar shows `gowi`
- [ ] Refresh button still works (⌘R), settings gear still opens Settings
- [ ] Rate-limit orange dot still appears on refresh button when applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)