### PR TITLE
net: harden SAML URL parsing and stop leaking HTTP bodies into errors

### DIFF
--- a/Sources/Gowi/Auth/DeviceFlowClient.swift
+++ b/Sources/Gowi/Auth/DeviceFlowClient.swift
@@ -156,8 +156,7 @@ struct DeviceFlowClient {
         do {
             let (data, response) = try await session.data(for: req)
             if let http = response as? HTTPURLResponse, !(200...299).contains(http.statusCode) {
-                let snippet = String(data: data.prefix(200), encoding: .utf8) ?? ""
-                throw DeviceFlowError.unexpected("HTTP \(http.statusCode): \(snippet)")
+                throw DeviceFlowError.unexpected("GitHub returned HTTP \(http.statusCode).")
             }
             return data
         } catch let e as DeviceFlowError {

--- a/Sources/Gowi/Net/GitHubClient.swift
+++ b/Sources/Gowi/Net/GitHubClient.swift
@@ -5,7 +5,7 @@ enum GitHubError: Error, LocalizedError {
     case unauthorized              // 401 from server; token is dead
     case samlRequired(URL)         // org enforces SAML SSO; token needs authorization
     case transport(String)
-    case http(Int, String)
+    case http(Int)
     case graphQL([String])         // non-empty errors array in response
     case decoding(String)
     case notFound(String)          // repo or resource missing / inaccessible
@@ -16,7 +16,7 @@ enum GitHubError: Error, LocalizedError {
         case .unauthorized:     return "GitHub rejected the access token. Please sign in again."
         case .samlRequired:     return "One or more repos require GitHub SSO authorization."
         case .transport(let s): return "Network error: \(s)"
-        case .http(let c, let s): return "HTTP \(c): \(s)"
+        case .http(let c):      return "GitHub returned HTTP \(c)."
         case .graphQL(let msgs): return msgs.joined(separator: "; ")
         case .decoding(let s):  return "Could not parse GitHub response: \(s)"
         case .notFound(let s):  return s
@@ -93,8 +93,7 @@ final class GitHubClient {
                 throw GitHubError.samlRequired(authURL ?? Config.tokenSettingsURL)
             }
             if !(200...299).contains(http.statusCode) {
-                let snippet = String(data: data.prefix(300), encoding: .utf8) ?? ""
-                throw GitHubError.http(http.statusCode, snippet)
+                throw GitHubError.http(http.statusCode)
             }
         }
         return data
@@ -135,11 +134,24 @@ final class GitHubClient {
 
     // MARK: - SAML helpers
 
-    /// Parses `X-GitHub-SSO: required; url=<URL>` and returns the URL component.
+    /// Parses `X-GitHub-SSO: required; url=<URL>` and returns the URL component
+    /// only when it points to an `https://...github.com` resource. Anything
+    /// else (different scheme, different host, malformed) returns nil so the
+    /// caller falls back to a known-safe URL.
     static func parseSSOHeader(_ header: String?) -> URL? {
-        guard let header,
-              let urlRange = header.range(of: "url=") else { return nil }
-        return URL(string: String(header[urlRange.upperBound...]))
+        guard let header else { return nil }
+        let urlValue = header
+            .split(separator: ";")
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .first { $0.hasPrefix("url=") }
+            .map { String($0.dropFirst("url=".count)) }
+        guard let urlValue,
+              let url = URL(string: urlValue),
+              url.scheme == "https",
+              let host = url.host,
+              host == "github.com" || host.hasSuffix(".github.com")
+        else { return nil }
+        return url
     }
 
     static func isSAMLError(_ message: String) -> Bool {

--- a/Tests/GowiTests/GitHubClientTests.swift
+++ b/Tests/GowiTests/GitHubClientTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+
+final class GitHubClientTests: XCTestCase {
+
+    // MARK: - parseSSOHeader
+
+    func testSSOHeaderAcceptsGitHubHTTPSURL() {
+        let url = GitHubClient.parseSSOHeader(
+            "required; url=https://github.com/orgs/acme/sso?authorization_request=abc"
+        )
+        XCTAssertEqual(url?.host, "github.com")
+        XCTAssertEqual(url?.scheme, "https")
+    }
+
+    func testSSOHeaderAcceptsSubdomainOfGitHub() {
+        let url = GitHubClient.parseSSOHeader("required; url=https://api.github.com/foo")
+        XCTAssertEqual(url?.host, "api.github.com")
+    }
+
+    func testSSOHeaderRejectsNonHTTPSScheme() {
+        XCTAssertNil(GitHubClient.parseSSOHeader("required; url=javascript:alert(1)"))
+        XCTAssertNil(GitHubClient.parseSSOHeader("required; url=http://github.com/orgs/acme/sso"))
+        XCTAssertNil(GitHubClient.parseSSOHeader("required; url=file:///etc/passwd"))
+    }
+
+    func testSSOHeaderRejectsForeignHost() {
+        XCTAssertNil(GitHubClient.parseSSOHeader("required; url=https://evil.example.com/sso"))
+        XCTAssertNil(GitHubClient.parseSSOHeader("required; url=https://github.com.evil.example/sso"))
+    }
+
+    func testSSOHeaderTolerantOfWhitespaceAndOrdering() {
+        let url = GitHubClient.parseSSOHeader("  required ;   url=https://github.com/orgs/acme/sso  ")
+        XCTAssertEqual(url?.host, "github.com")
+    }
+
+    func testSSOHeaderNilOnMissingURL() {
+        XCTAssertNil(GitHubClient.parseSSOHeader(nil))
+        XCTAssertNil(GitHubClient.parseSSOHeader("required"))
+        XCTAssertNil(GitHubClient.parseSSOHeader(""))
+    }
+
+    // MARK: - GitHubError descriptions
+
+    func testHTTPErrorDescriptionDoesNotIncludeBody() {
+        let desc = GitHubError.http(500).errorDescription ?? ""
+        XCTAssertTrue(desc.contains("500"))
+        XCTAssertFalse(desc.lowercased().contains("html"))
+        XCTAssertFalse(desc.contains("<"))
+    }
+}


### PR DESCRIPTION
## Summary

Three small hardening fixes from the security review on `claude/security-review-GTBSL`:

- **SAML URL allow-list.** `GitHubClient.parseSSOHeader` previously took everything after `url=` in the `X-GitHub-SSO` response header and constructed a `URL` from it, which `MainWindow` then handed straight to `NSWorkspace.shared.open`. It now splits on `;`, trims whitespace, and only accepts `https://` URLs whose host is `github.com` or a subdomain. Anything else returns nil so the caller falls back to the known-safe token settings URL.
- **No more HTTP body snippets in errors.** `GitHubError.http` used to carry the first 300 bytes of the response body, which propagated through `errorDescription` into `model.lastError` and the UI. The case is now `http(Int)` and the message is just `"GitHub returned HTTP <code>."`. Same redaction applied to `DeviceFlowError.unexpected` on the device-flow HTTP failure path.
- **Tests.** New `GitHubClientTests` lock in the SSO URL allow-list (accepts `github.com` / `*.github.com` over HTTPS, rejects other schemes, foreign hosts, suffix-spoofs like `github.com.evil.example`, tolerates whitespace) and verify the redacted HTTP error description.

These are the LOW-severity items 3, 4, and 5 from the security review. The HIGH item (Sparkle public key) was already resolved on `main` in #20, and the MEDIUM item (GitHub App migration) is tracked in #27.

## Test plan
- [ ] CI green on macOS
- [ ] `GitHubClientTests` pass — covers allow-list and redacted error
- [ ] Sanity-check the SAML banner flow against a real org with SSO enforcement (manual)

https://claude.ai/code/session_01Q1SwhFd9FBxF469JfQkwkv

---
_Generated by [Claude Code](https://claude.ai/code/session_01Q1SwhFd9FBxF469JfQkwkv)_