### PR TITLE
notify: per-repo macOS notifications for new PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,11 +37,12 @@ Register a GitHub OAuth App at https://github.com/settings/applications/new with
 
 ## Architecture
 
-Three `ObservableObject` singletons are created in `GowiApp.init()` and injected via `.environmentObject` into all scenes:
+Four `ObservableObject` singletons are created in `GowiApp.init()` and injected via `.environmentObject` into all scenes:
 
 - **`AuthService`** — owns the device-flow OAuth lifecycle and keychain token. Exposes `@Published var state: AuthState` (`.signedOut`, `.awaitingUserCode`, `.signedIn`, `.failed`). Views observe this to gate the UI.
 - **`RepoStore`** — persists tracked repos to `UserDefaults` as `["owner/name"]` strings. CRUD only.
 - **`AppModel`** — the root fetch/state machine. Subscribes to both `AuthService.$state` and `RepoStore.$repos` via Combine. On sign-in or repo change it triggers a batch fetch and updates `@Published var state: PRState` (`.signedOut`, `.loading`, `.loaded([RepoGroup])`, `.error`). Also owns the periodic tick loop and rate-limit pause logic.
+- **`NotificationService`** — owns macOS notification authorization, the per-repo opt-in set (`enabledRepos`), and a persisted seen-PR-IDs map. `AppModel` calls `process(groups:)` after each refresh; the service seeds first-time-observed repos silently, skips errored groups, and posts a banner per new PR (or a summary when more than three arrive at once). Tapping a notification opens the PR URL via `NSWorkspace`.
 
 `AppModel` holds a `GitHubClient` whose token is supplied lazily via a closure (`{ auth?.accessToken }`) so it always reflects the current keychain state without holding a strong ref to `AuthService`.
 
@@ -69,6 +70,9 @@ Three `ObservableObject` singletons are created in `GowiApp.init()` and injected
 | Refresh interval | `UserDefaults` | `refreshIntervalMinutes` |
 | Last seen (new-PR dot) | `UserDefaults` | `lastSeenAt` |
 | PR list cache | JSON file | `~/Library/Application Support/gowi/cache.json` |
+| Notification-enabled repos | `UserDefaults` | `notificationEnabledRepos` |
+| Notification seen PR IDs | `UserDefaults` | `seenPRIds` |
+| Notification seeded repos | `UserDefaults` | `seededRepos` |
 
 ### Scenes and views
 
@@ -78,6 +82,17 @@ Three SwiftUI scenes declared in `GowiApp`:
 - `MenuBarExtra` (`.window` style) → `MenuBarRoot`
 
 `MainWindow` is the primary decision view — it switches between `SignInView`, empty/error/loading states, and `PRListView` based on `auth.state` and `model.state`. The SAML banner is injected above the content stack when `model.samlAuthURL != nil`.
+
+## Testing
+
+Each service with non-trivial state-machine logic ships with `Tests/GowiTests/<ServiceName>Tests.swift`. Use isolated `UserDefaults` suites (unique suite name per `setUp`) and inject spy doubles via the same injectable parameters the production code exposes. Tests should cover:
+
+- Initial state and persistence across reload
+- Core state transitions (happy path and no-op cases)
+- Error / skipped cases
+- Pruning / cleanup paths
+
+For side-effecting dependencies (network, notification posting, keychain), extract a one-method protocol in the production file and conform the real type via an empty extension. Inject a spy in tests. Do not leave new services untested.
 
 ## Commit conventions
 

--- a/Sources/Gowi/AppModel.swift
+++ b/Sources/Gowi/AppModel.swift
@@ -30,14 +30,16 @@ final class AppModel: ObservableObject {
     let github: GitHubClient
     private let auth: AuthService
     private let store: RepoStore
+    private let notifications: NotificationService
     private var cancellables = Set<AnyCancellable>()
     private var refreshTask: Task<Void, Never>?
     private var tickTask: Task<Void, Never>?
     private var rateLimitPauseUntil: Date?
 
-    init(auth: AuthService, store: RepoStore) {
+    init(auth: AuthService, store: RepoStore, notifications: NotificationService) {
         self.auth = auth
         self.store = store
+        self.notifications = notifications
         self.github = GitHubClient(tokenProvider: { [weak auth] in auth?.accessToken })
 
         auth.$state
@@ -164,6 +166,7 @@ final class AppModel: ObservableObject {
 
             state = .loaded(groups)
             lastRefresh = Date()
+            notifications.process(groups: groups)
             PRCache.shared.save(groups)
         } catch GitHubError.unauthorized {
             auth.signOut()
@@ -183,6 +186,7 @@ final class AppModel: ObservableObject {
             if let idx = groups.firstIndex(where: { $0.repo == repo }) {
                 groups[idx] = RepoGroup(repo: repo, pullRequests: result.pullRequests, totalCount: result.totalCount, error: nil)
                 state = .loaded(groups)
+                notifications.process(groups: [groups[idx]])
                 PRCache.shared.save(groups)
             }
         } catch GitHubError.unauthorized {

--- a/Sources/Gowi/GowiApp.swift
+++ b/Sources/Gowi/GowiApp.swift
@@ -7,14 +7,17 @@ struct GowiApp: App {
     @StateObject private var auth: AuthService
     @StateObject private var model: AppModel
     @StateObject private var store: RepoStore
+    @StateObject private var notifications: NotificationService
     private let updaterController: SPUStandardUpdaterController
 
     init() {
         let auth = AuthService()
         let store = RepoStore()
+        let notifications = NotificationService(store: store)
         _auth = StateObject(wrappedValue: auth)
         _store = StateObject(wrappedValue: store)
-        _model = StateObject(wrappedValue: AppModel(auth: auth, store: store))
+        _notifications = StateObject(wrappedValue: notifications)
+        _model = StateObject(wrappedValue: AppModel(auth: auth, store: store, notifications: notifications))
         updaterController = SPUStandardUpdaterController(startingUpdater: true, updaterDelegate: nil, userDriverDelegate: nil)
     }
 
@@ -24,6 +27,7 @@ struct GowiApp: App {
                 .environmentObject(model)
                 .environmentObject(auth)
                 .environmentObject(store)
+                .environmentObject(notifications)
                 .frame(minWidth: 360, minHeight: 420)
         }
         .defaultSize(width: 480, height: 640)
@@ -40,6 +44,7 @@ struct GowiApp: App {
                 .environmentObject(model)
                 .environmentObject(auth)
                 .environmentObject(store)
+                .environmentObject(notifications)
         }
 
         MenuBarExtra {
@@ -47,6 +52,7 @@ struct GowiApp: App {
                 .environmentObject(model)
                 .environmentObject(auth)
                 .environmentObject(store)
+                .environmentObject(notifications)
         } label: {
             MenuBarLabel(model: model)
         }

--- a/Sources/Gowi/Services/NotificationService.swift
+++ b/Sources/Gowi/Services/NotificationService.swift
@@ -1,0 +1,239 @@
+import Foundation
+import AppKit
+import Combine
+import UserNotifications
+
+@MainActor
+final class NotificationService: NSObject, ObservableObject {
+    @Published private(set) var enabledRepos: Set<String> = []
+    @Published private(set) var authorizationStatus: UNAuthorizationStatus = .notDetermined
+
+    private let defaults: UserDefaults
+    private let center: UNUserNotificationCenter
+    private var seenPRIds: [String: Set<String>] = [:]
+    private var seededRepos: Set<String> = []
+    private var cancellables = Set<AnyCancellable>()
+
+    private enum Keys {
+        static let enabled = "notifyOnNewPR"
+        static let seenIds = "seenPRIds"
+        static let seeded = "seededRepos"
+    }
+
+    init(store: RepoStore, defaults: UserDefaults = .standard, center: UNUserNotificationCenter = .current()) {
+        self.defaults = defaults
+        self.center = center
+        super.init()
+
+        loadFromDefaults()
+        center.delegate = self
+
+        Task { await refreshAuthorizationStatus() }
+
+        store.$repos
+            .dropFirst()
+            .sink { [weak self] repos in
+                self?.pruneRemovedRepos(currentRepos: repos)
+            }
+            .store(in: &cancellables)
+
+        NotificationCenter.default.addObserver(
+            forName: NSApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            guard let self else { return }
+            Task { await self.refreshAuthorizationStatus() }
+        }
+    }
+
+    // MARK: - Per-repo enabled state
+
+    func isEnabled(_ repo: TrackedRepo) -> Bool {
+        enabledRepos.contains(repo.id)
+    }
+
+    func setEnabled(_ enabled: Bool, for repo: TrackedRepo) async {
+        if enabled {
+            _ = await requestAuthorizationIfNeeded()
+            enabledRepos.insert(repo.id)
+        } else {
+            enabledRepos.remove(repo.id)
+            // Clear seen state so a later re-enable seeds silently rather than
+            // notifying for every currently-open PR.
+            seenPRIds.removeValue(forKey: repo.id)
+            seededRepos.remove(repo.id)
+        }
+        persist()
+    }
+
+    // MARK: - Authorization
+
+    @discardableResult
+    func requestAuthorizationIfNeeded() async -> Bool {
+        await refreshAuthorizationStatus()
+        switch authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            return true
+        case .denied:
+            return false
+        case .notDetermined:
+            let granted = (try? await center.requestAuthorization(options: [.alert, .sound])) ?? false
+            await refreshAuthorizationStatus()
+            return granted
+        @unknown default:
+            return false
+        }
+    }
+
+    func refreshAuthorizationStatus() async {
+        let settings = await center.notificationSettings()
+        authorizationStatus = settings.authorizationStatus
+    }
+
+    // MARK: - Test
+
+    func sendTestNotification() {
+        let content = UNMutableNotificationContent()
+        content.title = "gowi"
+        content.body = "Test notification — you'll see one of these when a new PR is raised."
+        content.sound = .default
+        let req = UNNotificationRequest(
+            identifier: "test-\(UUID().uuidString)",
+            content: content,
+            trigger: nil
+        )
+        center.add(req)
+    }
+
+    // MARK: - Diff & post
+
+    func process(groups: [RepoGroup]) {
+        var didMutate = false
+
+        for group in groups {
+            if group.error != nil { continue }
+
+            let repoID = group.repo.id
+            let currentIds = Set(group.pullRequests.map(\.id))
+
+            if !seededRepos.contains(repoID) {
+                seenPRIds[repoID] = currentIds
+                seededRepos.insert(repoID)
+                didMutate = true
+                continue
+            }
+
+            if enabledRepos.contains(repoID) {
+                let previous = seenPRIds[repoID] ?? []
+                let newIds = currentIds.subtracting(previous)
+                if !newIds.isEmpty {
+                    let newPRs = group.pullRequests.filter { newIds.contains($0.id) }
+                    postNotifications(for: newPRs, repo: group.repo)
+                }
+            }
+
+            // Union with previous so a PR that scrolls past the 50-item window
+            // and later returns isn't re-notified.
+            seenPRIds[repoID] = currentIds.union(seenPRIds[repoID] ?? [])
+            didMutate = true
+        }
+
+        if didMutate { persist() }
+    }
+
+    // MARK: - Posting
+
+    private func postNotifications(for prs: [PullRequest], repo: TrackedRepo) {
+        if prs.count > 3 {
+            postSummary(count: prs.count, repo: repo)
+        } else {
+            for pr in prs {
+                postSingle(pr: pr, repo: repo)
+            }
+        }
+    }
+
+    private func postSingle(pr: PullRequest, repo: TrackedRepo) {
+        let content = UNMutableNotificationContent()
+        content.title = repo.nameWithOwner
+        let author = pr.authorLogin ?? "Someone"
+        content.body = "\(author) raised a new PR — \(pr.title)"
+        content.sound = .default
+        content.userInfo = ["url": pr.url.absoluteString]
+        let req = UNNotificationRequest(identifier: pr.id, content: content, trigger: nil)
+        center.add(req)
+    }
+
+    private func postSummary(count: Int, repo: TrackedRepo) {
+        let content = UNMutableNotificationContent()
+        content.title = repo.nameWithOwner
+        content.body = "\(count) new pull requests"
+        content.sound = .default
+        content.userInfo = ["url": repo.pullsURL.absoluteString]
+        let id = "summary-\(repo.id)-\(Int(Date().timeIntervalSince1970))"
+        let req = UNNotificationRequest(identifier: id, content: content, trigger: nil)
+        center.add(req)
+    }
+
+    // MARK: - Cleanup
+
+    private func pruneRemovedRepos(currentRepos: [TrackedRepo]) {
+        let currentIDs = Set(currentRepos.map(\.id))
+        let staleEnabled = enabledRepos.subtracting(currentIDs)
+        let staleSeeded = seededRepos.subtracting(currentIDs)
+        let staleSeen = Set(seenPRIds.keys).subtracting(currentIDs)
+        guard !staleEnabled.isEmpty || !staleSeeded.isEmpty || !staleSeen.isEmpty else { return }
+        enabledRepos.subtract(staleEnabled)
+        seededRepos.subtract(staleSeeded)
+        for key in staleSeen { seenPRIds.removeValue(forKey: key) }
+        persist()
+    }
+
+    // MARK: - Persistence
+
+    private func loadFromDefaults() {
+        if let arr = defaults.stringArray(forKey: Keys.enabled) {
+            enabledRepos = Set(arr)
+        }
+        if let arr = defaults.stringArray(forKey: Keys.seeded) {
+            seededRepos = Set(arr)
+        }
+        if let dict = defaults.dictionary(forKey: Keys.seenIds) as? [String: [String]] {
+            seenPRIds = dict.mapValues { Set($0) }
+        }
+    }
+
+    private func persist() {
+        defaults.set(Array(enabledRepos), forKey: Keys.enabled)
+        defaults.set(Array(seededRepos), forKey: Keys.seeded)
+        let dict: [String: [String]] = seenPRIds.mapValues { Array($0) }
+        defaults.set(dict, forKey: Keys.seenIds)
+    }
+}
+
+// MARK: - UNUserNotificationCenterDelegate
+
+extension NotificationService: UNUserNotificationCenterDelegate {
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        willPresent notification: UNNotification,
+        withCompletionHandler completionHandler: @escaping (UNNotificationPresentationOptions) -> Void
+    ) {
+        completionHandler([.banner, .sound])
+    }
+
+    nonisolated func userNotificationCenter(
+        _ center: UNUserNotificationCenter,
+        didReceive response: UNNotificationResponse,
+        withCompletionHandler completionHandler: @escaping () -> Void
+    ) {
+        let userInfo = response.notification.request.content.userInfo
+        if let urlString = userInfo["url"] as? String, let url = URL(string: urlString) {
+            DispatchQueue.main.async {
+                NSWorkspace.shared.open(url)
+            }
+        }
+        completionHandler()
+    }
+}

--- a/Sources/Gowi/Services/NotificationService.swift
+++ b/Sources/Gowi/Services/NotificationService.swift
@@ -3,24 +3,52 @@ import AppKit
 import Combine
 import UserNotifications
 
+// MARK: - Testability protocol
+
+// Covers the subset of UNUserNotificationCenter operations this service needs,
+// so tests can inject a stub without requiring a live app bundle.
+protocol NotificationCenterProtocol: AnyObject {
+    var delegate: UNUserNotificationCenterDelegate? { get set }
+    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool
+    func currentAuthorizationStatus() async -> UNAuthorizationStatus
+    func add(_ request: UNNotificationRequest)
+}
+
+extension UNUserNotificationCenter: NotificationCenterProtocol {
+    func currentAuthorizationStatus() async -> UNAuthorizationStatus {
+        await notificationSettings().authorizationStatus
+    }
+
+    func add(_ request: UNNotificationRequest) {
+        add(request, withCompletionHandler: nil)
+    }
+}
+
 @MainActor
 final class NotificationService: NSObject, ObservableObject {
     @Published private(set) var enabledRepos: Set<String> = []
     @Published private(set) var authorizationStatus: UNAuthorizationStatus = .notDetermined
 
+    var isAuthorized: Bool {
+        switch authorizationStatus {
+        case .authorized, .provisional, .ephemeral: return true
+        default: return false
+        }
+    }
+
     private let defaults: UserDefaults
-    private let center: UNUserNotificationCenter
-    private var seenPRIds: [String: Set<String>] = [:]
-    private var seededRepos: Set<String> = []
+    private let center: NotificationCenterProtocol
+    var seenPRIds: [String: Set<String>] = [:]
+    var seededRepos: Set<String> = []
     private var cancellables = Set<AnyCancellable>()
 
     private enum Keys {
-        static let enabled = "notifyOnNewPR"
+        static let enabled = "notificationEnabledRepos"
         static let seenIds = "seenPRIds"
         static let seeded = "seededRepos"
     }
 
-    init(store: RepoStore, defaults: UserDefaults = .standard, center: UNUserNotificationCenter = .current()) {
+    init(store: RepoStore, defaults: UserDefaults = .standard, center: NotificationCenterProtocol = UNUserNotificationCenter.current()) {
         self.defaults = defaults
         self.center = center
         super.init()
@@ -87,23 +115,21 @@ final class NotificationService: NSObject, ObservableObject {
     }
 
     func refreshAuthorizationStatus() async {
-        let settings = await center.notificationSettings()
-        authorizationStatus = settings.authorizationStatus
+        authorizationStatus = await center.currentAuthorizationStatus()
     }
 
-    // MARK: - Test
+    // MARK: - Test notification
 
     func sendTestNotification() {
         let content = UNMutableNotificationContent()
         content.title = "gowi"
         content.body = "Test notification — you'll see one of these when a new PR is raised."
         content.sound = .default
-        let req = UNNotificationRequest(
+        center.add(UNNotificationRequest(
             identifier: "test-\(UUID().uuidString)",
             content: content,
             trigger: nil
-        )
-        center.add(req)
+        ))
     }
 
     // MARK: - Diff & post
@@ -133,9 +159,7 @@ final class NotificationService: NSObject, ObservableObject {
                 }
             }
 
-            // Union with previous so a PR that scrolls past the 50-item window
-            // and later returns isn't re-notified.
-            seenPRIds[repoID] = currentIds.union(seenPRIds[repoID] ?? [])
+            seenPRIds[repoID] = currentIds
             didMutate = true
         }
 
@@ -145,12 +169,11 @@ final class NotificationService: NSObject, ObservableObject {
     // MARK: - Posting
 
     private func postNotifications(for prs: [PullRequest], repo: TrackedRepo) {
+        // >3 intentionally exclusive: 4+ get a summary, 1–3 get individual banners.
         if prs.count > 3 {
             postSummary(count: prs.count, repo: repo)
         } else {
-            for pr in prs {
-                postSingle(pr: pr, repo: repo)
-            }
+            for pr in prs { postSingle(pr: pr, repo: repo) }
         }
     }
 
@@ -161,8 +184,7 @@ final class NotificationService: NSObject, ObservableObject {
         content.body = "\(author) raised a new PR — \(pr.title)"
         content.sound = .default
         content.userInfo = ["url": pr.url.absoluteString]
-        let req = UNNotificationRequest(identifier: pr.id, content: content, trigger: nil)
-        center.add(req)
+        center.add(UNNotificationRequest(identifier: pr.id, content: content, trigger: nil))
     }
 
     private func postSummary(count: Int, repo: TrackedRepo) {
@@ -172,8 +194,7 @@ final class NotificationService: NSObject, ObservableObject {
         content.sound = .default
         content.userInfo = ["url": repo.pullsURL.absoluteString]
         let id = "summary-\(repo.id)-\(Int(Date().timeIntervalSince1970))"
-        let req = UNNotificationRequest(identifier: id, content: content, trigger: nil)
-        center.add(req)
+        center.add(UNNotificationRequest(identifier: id, content: content, trigger: nil))
     }
 
     // MARK: - Cleanup

--- a/Sources/Gowi/UI/GeneralPane.swift
+++ b/Sources/Gowi/UI/GeneralPane.swift
@@ -1,7 +1,10 @@
 import SwiftUI
+import AppKit
 import ServiceManagement
+import UserNotifications
 
 struct GeneralPane: View {
+    @EnvironmentObject private var notifications: NotificationService
     @AppStorage("refreshIntervalMinutes") private var refreshIntervalMinutes: Int = 5
     @AppStorage("showWindowOnLaunch") private var showWindowOnLaunch: Bool = false
 
@@ -29,8 +32,50 @@ struct GeneralPane: View {
             }
 
             Toggle("Show main window on launch", isOn: $showWindowOnLaunch)
+
+            Section("Notifications") {
+                notificationStatusRow
+                Button("Send test notification") {
+                    notifications.sendTestNotification()
+                }
+                .disabled(notifications.authorizationStatus == .denied)
+            }
         }
         .padding()
+        .task { await notifications.refreshAuthorizationStatus() }
+    }
+
+    @ViewBuilder
+    private var notificationStatusRow: some View {
+        switch notifications.authorizationStatus {
+        case .authorized, .provisional, .ephemeral:
+            Label("Notifications enabled", systemImage: "bell.fill")
+                .foregroundStyle(.secondary)
+        case .denied:
+            HStack {
+                Label("Notifications disabled in System Settings", systemImage: "bell.slash")
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Open System Settings") { openNotificationSettings() }
+            }
+        case .notDetermined:
+            HStack {
+                Label("Notifications not configured", systemImage: "bell")
+                    .foregroundStyle(.secondary)
+                Spacer()
+                Button("Request permission") {
+                    Task { await notifications.requestAuthorizationIfNeeded() }
+                }
+            }
+        @unknown default:
+            EmptyView()
+        }
+    }
+
+    private func openNotificationSettings() {
+        if let url = URL(string: "x-apple.systempreferences:com.apple.preference.notifications") {
+            NSWorkspace.shared.open(url)
+        }
     }
 
     private func setLaunchAtLogin(_ enabled: Bool) {

--- a/Sources/Gowi/UI/GeneralPane.swift
+++ b/Sources/Gowi/UI/GeneralPane.swift
@@ -38,7 +38,7 @@ struct GeneralPane: View {
                 Button("Send test notification") {
                     notifications.sendTestNotification()
                 }
-                .disabled(notifications.authorizationStatus == .denied)
+                .disabled(!notifications.isAuthorized)
             }
         }
         .padding()

--- a/Sources/Gowi/UI/RepositoriesPane.swift
+++ b/Sources/Gowi/UI/RepositoriesPane.swift
@@ -15,6 +15,7 @@ struct RepositoriesPane: View {
                 List(selection: $selectedRepo) {
                     ForEach(store.repos) { repo in
                         HStack {
+                            NotifyToggle(repo: repo)
                             Image(systemName: "folder")
                                 .foregroundStyle(.secondary)
                             Text(repo.nameWithOwner)
@@ -101,6 +102,26 @@ struct RepositoriesPane: View {
         }
         .frame(maxWidth: .infinity)
         .padding(.vertical, 32)
+    }
+}
+
+private struct NotifyToggle: View {
+    @EnvironmentObject private var notifications: NotificationService
+    let repo: TrackedRepo
+
+    var body: some View {
+        let isOn = Binding<Bool>(
+            get: { notifications.isEnabled(repo) },
+            set: { newValue in
+                Task { await notifications.setEnabled(newValue, for: repo) }
+            }
+        )
+        Toggle(isOn: isOn) {
+            Image(systemName: notifications.isEnabled(repo) ? "bell.fill" : "bell.slash")
+        }
+        .toggleStyle(.button)
+        .buttonStyle(.borderless)
+        .help(notifications.isEnabled(repo) ? "Notifications on for this repo" : "Notify on new PRs")
     }
 }
 

--- a/Tests/GowiTests/NotificationServiceTests.swift
+++ b/Tests/GowiTests/NotificationServiceTests.swift
@@ -1,0 +1,237 @@
+@testable import Gowi
+import XCTest
+import UserNotifications
+
+// MARK: - Test doubles
+
+private final class MockCenter: NotificationCenterProtocol {
+    var delegate: UNUserNotificationCenterDelegate?
+    var addedRequests: [UNNotificationRequest] = []
+    var stubbedStatus: UNAuthorizationStatus = .notDetermined
+
+    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool { false }
+    func currentAuthorizationStatus() async -> UNAuthorizationStatus { stubbedStatus }
+    func add(_ request: UNNotificationRequest) { addedRequests.append(request) }
+}
+
+// MARK: - Helpers
+
+private func makePR(id: String, repo: TrackedRepo) -> PullRequest {
+    PullRequest(
+        id: id,
+        number: 1,
+        title: "PR \(id)",
+        url: URL(string: "https://github.com/\(repo.nameWithOwner)/pull/1")!,
+        authorLogin: "author",
+        authorAvatarURL: nil,
+        isDraft: false,
+        createdAt: Date(),
+        updatedAt: Date(),
+        repo: repo,
+        reviewDecision: .noReview,
+        checkStatus: .noChecks
+    )
+}
+
+private func makeGroup(repo: TrackedRepo, prs: [PullRequest] = [], error: String? = nil) -> RepoGroup {
+    RepoGroup(repo: repo, pullRequests: prs, totalCount: prs.count, error: error)
+}
+
+// MARK: - Tests
+
+@MainActor
+final class NotificationServiceTests: XCTestCase {
+    private var defaults: UserDefaults!
+    private var store: RepoStore!
+    private var center: MockCenter!
+
+    override func setUp() async throws {
+        let uid = UUID().uuidString
+        defaults = UserDefaults(suiteName: "gowi.tests.notify.\(uid)")!
+        store = RepoStore(defaults: UserDefaults(suiteName: "gowi.tests.notify.store.\(uid)")!)
+        center = MockCenter()
+    }
+
+    override func tearDown() async throws {
+        defaults.removePersistentDomain(forName: defaults.description)
+        defaults = nil
+        store = nil
+        center = nil
+    }
+
+    private func makeService(enabledRepos: [String] = []) -> NotificationService {
+        if !enabledRepos.isEmpty {
+            defaults.set(enabledRepos, forKey: "notificationEnabledRepos")
+        }
+        return NotificationService(store: store, defaults: defaults, center: center)
+    }
+
+    // MARK: - Seeding
+
+    func testFirstObserveSeedsSilently() {
+        let repo = TrackedRepo(owner: "apple", name: "swift")
+        let pr = makePR(id: "pr1", repo: repo)
+        let svc = makeService(enabledRepos: [repo.id])
+
+        svc.process(groups: [makeGroup(repo: repo, prs: [pr])])
+
+        XCTAssertTrue(svc.seededRepos.contains(repo.id))
+        XCTAssertEqual(svc.seenPRIds[repo.id], ["pr1"])
+        XCTAssertTrue(center.addedRequests.isEmpty, "First observe must not post notifications")
+    }
+
+    func testSubsequentProcessWithSamePRsPostsNothing() {
+        let repo = TrackedRepo(owner: "apple", name: "swift")
+        let pr = makePR(id: "pr1", repo: repo)
+        let svc = makeService(enabledRepos: [repo.id])
+
+        svc.process(groups: [makeGroup(repo: repo, prs: [pr])])
+        svc.process(groups: [makeGroup(repo: repo, prs: [pr])])
+
+        XCTAssertTrue(center.addedRequests.isEmpty)
+    }
+
+    // MARK: - New PR detection
+
+    func testNewPRPostsNotificationWhenEnabled() {
+        let repo = TrackedRepo(owner: "apple", name: "swift")
+        let pr1 = makePR(id: "pr1", repo: repo)
+        let pr2 = makePR(id: "pr2", repo: repo)
+        let svc = makeService(enabledRepos: [repo.id])
+
+        svc.process(groups: [makeGroup(repo: repo, prs: [pr1])])
+        svc.process(groups: [makeGroup(repo: repo, prs: [pr1, pr2])])
+
+        XCTAssertEqual(center.addedRequests.count, 1)
+        XCTAssertEqual(center.addedRequests[0].identifier, "pr2")
+    }
+
+    func testNewPRDoesNotPostWhenDisabled() {
+        let repo = TrackedRepo(owner: "apple", name: "swift")
+        let pr1 = makePR(id: "pr1", repo: repo)
+        let pr2 = makePR(id: "pr2", repo: repo)
+        let svc = makeService()  // not enabled
+
+        svc.process(groups: [makeGroup(repo: repo, prs: [pr1])])
+        svc.process(groups: [makeGroup(repo: repo, prs: [pr1, pr2])])
+
+        XCTAssertTrue(center.addedRequests.isEmpty)
+    }
+
+    func testFourOrMoreNewPRsPostSummary() {
+        let repo = TrackedRepo(owner: "apple", name: "swift")
+        let svc = makeService(enabledRepos: [repo.id])
+
+        svc.process(groups: [makeGroup(repo: repo, prs: [])])  // seed empty
+
+        let prs = (1...4).map { makePR(id: "pr\($0)", repo: repo) }
+        svc.process(groups: [makeGroup(repo: repo, prs: prs)])
+
+        XCTAssertEqual(center.addedRequests.count, 1)
+        XCTAssertTrue(center.addedRequests[0].identifier.hasPrefix("summary-"))
+    }
+
+    func testThreeOrFewerNewPRsPostIndividually() {
+        let repo = TrackedRepo(owner: "apple", name: "swift")
+        let svc = makeService(enabledRepos: [repo.id])
+
+        svc.process(groups: [makeGroup(repo: repo, prs: [])])  // seed empty
+
+        let prs = (1...3).map { makePR(id: "pr\($0)", repo: repo) }
+        svc.process(groups: [makeGroup(repo: repo, prs: prs)])
+
+        XCTAssertEqual(center.addedRequests.count, 3)
+        XCTAssertEqual(Set(center.addedRequests.map(\.identifier)), ["pr1", "pr2", "pr3"])
+    }
+
+    // MARK: - Error groups
+
+    func testErrorGroupIsSkipped() {
+        let repo = TrackedRepo(owner: "apple", name: "swift")
+        let svc = makeService(enabledRepos: [repo.id])
+
+        svc.process(groups: [makeGroup(repo: repo, prs: [], error: "rate limited")])
+
+        XCTAssertFalse(svc.seededRepos.contains(repo.id), "Errored group must not seed")
+        XCTAssertTrue(center.addedRequests.isEmpty)
+    }
+
+    // MARK: - seenPRIds replace, not union
+
+    func testSeenIdsReplacedNotUnioned() {
+        let repo = TrackedRepo(owner: "apple", name: "swift")
+        let pr1 = makePR(id: "pr1", repo: repo)
+        let pr2 = makePR(id: "pr2", repo: repo)
+        let svc = makeService(enabledRepos: [repo.id])
+
+        svc.process(groups: [makeGroup(repo: repo, prs: [pr1, pr2])])  // seed
+        svc.process(groups: [makeGroup(repo: repo, prs: [pr2])])        // pr1 closed
+
+        XCTAssertEqual(svc.seenPRIds[repo.id], ["pr2"],
+                       "Closed PR must not accumulate in seenPRIds")
+    }
+
+    func testClosedPRTriggersNewNotificationOnReopen() {
+        let repo = TrackedRepo(owner: "apple", name: "swift")
+        let pr1 = makePR(id: "pr1", repo: repo)
+        let pr2 = makePR(id: "pr2", repo: repo)
+        let svc = makeService(enabledRepos: [repo.id])
+
+        svc.process(groups: [makeGroup(repo: repo, prs: [pr1, pr2])])  // seed
+        svc.process(groups: [makeGroup(repo: repo, prs: [pr2])])        // pr1 gone
+        svc.process(groups: [makeGroup(repo: repo, prs: [pr1, pr2])])  // pr1 reappears
+
+        XCTAssertEqual(center.addedRequests.count, 1)
+        XCTAssertEqual(center.addedRequests[0].identifier, "pr1")
+    }
+
+    // MARK: - Persistence
+
+    func testEnabledReposPersistedAcrossReload() {
+        let repo = TrackedRepo(owner: "apple", name: "swift")
+        defaults.set([repo.id], forKey: "notificationEnabledRepos")
+
+        let svc = NotificationService(store: store, defaults: defaults, center: center)
+        XCTAssertTrue(svc.enabledRepos.contains(repo.id))
+
+        let reloaded = NotificationService(store: store, defaults: defaults, center: center)
+        XCTAssertTrue(reloaded.enabledRepos.contains(repo.id))
+    }
+
+    func testSeenIdsPersistedAcrossReload() {
+        let repo = TrackedRepo(owner: "apple", name: "swift")
+        let pr = makePR(id: "pr1", repo: repo)
+        let svc = makeService()
+
+        svc.process(groups: [makeGroup(repo: repo, prs: [pr])])
+
+        let reloaded = NotificationService(store: store, defaults: defaults, center: center)
+        XCTAssertEqual(reloaded.seenPRIds[repo.id], ["pr1"])
+        XCTAssertTrue(reloaded.seededRepos.contains(repo.id))
+    }
+
+    // MARK: - Pruning
+
+    func testPruningRemovesStaleEnabledAndSeenData() async {
+        let repoA = TrackedRepo(owner: "apple", name: "swift")
+        let repoB = TrackedRepo(owner: "apple", name: "swift-package-manager")
+        store.add(repoA)
+        store.add(repoB)
+        defaults.set([repoA.id, repoB.id], forKey: "notificationEnabledRepos")
+        let svc = NotificationService(store: store, defaults: defaults, center: center)
+
+        let prB = makePR(id: "prB1", repo: repoB)
+        svc.process(groups: [makeGroup(repo: repoB, prs: [prB])])
+
+        XCTAssertTrue(svc.enabledRepos.contains(repoB.id))
+        XCTAssertTrue(svc.seededRepos.contains(repoB.id))
+
+        store.remove(repoB)
+        await Task.yield()
+
+        XCTAssertFalse(svc.enabledRepos.contains(repoB.id))
+        XCTAssertFalse(svc.seededRepos.contains(repoB.id))
+        XCTAssertNil(svc.seenPRIds[repoB.id])
+        XCTAssertTrue(svc.enabledRepos.contains(repoA.id))
+    }
+}

--- a/Tests/GowiTests/NotificationServiceTests.swift
+++ b/Tests/GowiTests/NotificationServiceTests.swift
@@ -1,4 +1,3 @@
-@testable import Gowi
 import XCTest
 import UserNotifications
 


### PR DESCRIPTION
Adds a NotificationService singleton that owns notification authorization,
the per-repo opt-in set, and a persisted seen-PR-ids map. AppModel calls
notifications.process(groups:) after each refresh; the service skips
errored repos (so a transient fetch failure doesn't flood when it
recovers), seeds first-time-observed repos silently, and posts a banner
per new PR (or a summary banner when more than three arrive in one tick).
Tapping a notification opens the PR url via NSWorkspace.

Settings: each row in the Repositories tab gets a bell toggle; General
adds a Notifications section showing authorization status with a Request
permission / Open System Settings affordance and a Send test button.

https://claude.ai/code/session_01W5Zdfyp9pUFy4CqbcKY2VY