### PR TITLE
ui: fix repo header misclicks and add drag-to-reorder

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -85,6 +85,8 @@ Three SwiftUI scenes declared in `GowiApp`:
 
 ## Testing
 
+`GowiTests` compiles `Sources/Gowi` as direct source files (see `project.yml`) — there is no separate `Gowi` module. **Do not use `@testable import Gowi`**; it will fail with "no such module" in CI. Test files only need `import XCTest` plus any framework imports (`UserNotifications`, etc.). All production types are in scope automatically.
+
 Each service with non-trivial state-machine logic ships with `Tests/GowiTests/<ServiceName>Tests.swift`. Use isolated `UserDefaults` suites (unique suite name per `setUp`) and inject spy doubles via the same injectable parameters the production code exposes. Tests should cover:
 
 - Initial state and persistence across reload

--- a/Sources/Gowi/AppModel.swift
+++ b/Sources/Gowi/AppModel.swift
@@ -35,6 +35,7 @@ final class AppModel: ObservableObject {
     private var refreshTask: Task<Void, Never>?
     private var tickTask: Task<Void, Never>?
     private var rateLimitPauseUntil: Date?
+    private var suppressNextStoreRefresh = false
 
     init(auth: AuthService, store: RepoStore, notifications: NotificationService) {
         self.auth = auth
@@ -68,7 +69,12 @@ final class AppModel: ObservableObject {
             .dropFirst()
             .removeDuplicates()
             .sink { [weak self] _ in
-                self?.refresh()
+                guard let self else { return }
+                if self.suppressNextStoreRefresh {
+                    self.suppressNextStoreRefresh = false
+                    return
+                }
+                self.refresh()
             }
             .store(in: &cancellables)
 
@@ -132,6 +138,16 @@ final class AppModel: ObservableObject {
             guard let self else { return }
             await self.doRefreshSingleRepo(repo)
         }
+    }
+
+    /// Reorder repos without triggering a network re-fetch.
+    /// Updates the displayed groups immediately and persists the new order to the store.
+    func moveRepo(fromOffsets: IndexSet, toOffset: Int) {
+        guard case .loaded(var groups) = state else { return }
+        groups.move(fromOffsets: fromOffsets, toOffset: toOffset)
+        state = .loaded(groups)
+        suppressNextStoreRefresh = true
+        store.move(fromOffsets: fromOffsets, toOffset: toOffset)
     }
 
     // MARK: - private refresh

--- a/Sources/Gowi/UI/PRListView.swift
+++ b/Sources/Gowi/UI/PRListView.swift
@@ -6,27 +6,29 @@ struct PRListView: View {
     let onRetry: (TrackedRepo?) -> Void
     let onPullRefresh: () async -> Void
 
-    @EnvironmentObject private var store: RepoStore
+    @EnvironmentObject private var model: AppModel
     @State private var collapsed: Set<String> = []
-    @State private var dropTargetID: String?
 
     var body: some View {
         List {
             ForEach(groups) { group in
-                Section {
-                    if !collapsed.contains(group.id) {
-                        body(for: group)
-                    }
-                } header: {
+                DisclosureGroup(
+                    isExpanded: Binding(
+                        get: { !collapsed.contains(group.id) },
+                        set: { expanded in
+                            withAnimation(.easeInOut(duration: 0.15)) {
+                                if expanded { collapsed.remove(group.id) }
+                                else { collapsed.insert(group.id) }
+                            }
+                        }
+                    )
+                ) {
+                    body(for: group)
+                } label: {
                     repoHeader(group)
-                        .draggable(group.repo.nameWithOwner)
-                        .dropDestination(for: String.self, action: { items, _ in
-                            handleDrop(items: items, target: group)
-                        }, isTargeted: { targeted in
-                            dropTargetID = targeted ? group.id : nil
-                        })
                 }
             }
+            .onMove { model.moveRepo(fromOffsets: $0, toOffset: $1) }
         }
         .listStyle(.inset)
         .refreshable { await onPullRefresh() }
@@ -68,54 +70,27 @@ struct PRListView: View {
     }
 
     private func repoHeader(_ group: RepoGroup) -> some View {
-        let isCollapsed = collapsed.contains(group.id)
-        return Button {
-            withAnimation(.easeInOut(duration: 0.15)) {
-                if isCollapsed { collapsed.remove(group.id) }
-                else { collapsed.insert(group.id) }
-            }
-        } label: {
-            HStack(spacing: 8) {
-                Image(systemName: "chevron.right")
-                    .font(.caption.bold())
-                    .rotationEffect(.degrees(isCollapsed ? 0 : 90))
+        HStack(spacing: 8) {
+            Text(group.repo.nameWithOwner)
+                .font(.subheadline).bold()
+                .foregroundStyle(.secondary)
+
+            Spacer()
+
+            if group.error == nil {
+                Text("\(group.totalCount)")
+                    .font(.caption)
                     .foregroundStyle(.secondary)
-
-                Text(group.repo.nameWithOwner)
-                    .font(.subheadline).bold()
-                    .foregroundStyle(.secondary)
-
-                Spacer()
-
-                if group.error == nil {
-                    Text("\(group.totalCount)")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                }
+                    .monospacedDigit()
             }
-            .contentShape(Rectangle())
-            .opacity(dropTargetID == group.id ? 0.5 : 1.0)
         }
-        .buttonStyle(.plain)
-        .help("Click to collapse · Right-click to open in browser")
+        .contentShape(Rectangle())
+        .help("Right-click to open in browser")
         .contextMenu {
             Button("Open \(group.repo.nameWithOwner) in Browser") {
                 NSWorkspace.shared.open(group.repo.pullsURL)
             }
         }
-    }
-
-    @discardableResult
-    private func handleDrop(items: [String], target: RepoGroup) -> Bool {
-        guard let sourceName = items.first,
-              let sourceIdx = store.repos.firstIndex(where: { $0.nameWithOwner == sourceName }),
-              let destIdx = store.repos.firstIndex(where: { $0.id == target.repo.id }),
-              sourceIdx != destIdx
-        else { return false }
-        let toOffset = sourceIdx < destIdx ? destIdx + 1 : destIdx
-        store.move(fromOffsets: IndexSet(integer: sourceIdx), toOffset: toOffset)
-        return true
     }
 
     private func errorRow(_ message: String, repo: TrackedRepo) -> some View {

--- a/Sources/Gowi/UI/PRListView.swift
+++ b/Sources/Gowi/UI/PRListView.swift
@@ -6,7 +6,9 @@ struct PRListView: View {
     let onRetry: (TrackedRepo?) -> Void
     let onPullRefresh: () async -> Void
 
+    @EnvironmentObject private var store: RepoStore
     @State private var collapsed: Set<String> = []
+    @State private var dropTargetID: String?
 
     var body: some View {
         List {
@@ -17,6 +19,12 @@ struct PRListView: View {
                     }
                 } header: {
                     repoHeader(group)
+                        .draggable(group.repo.nameWithOwner)
+                        .dropDestination(for: String.self, action: { items, _ in
+                            handleDrop(items: items, target: group)
+                        }, isTargeted: { targeted in
+                            dropTargetID = targeted ? group.id : nil
+                        })
                 }
             }
         }
@@ -61,38 +69,53 @@ struct PRListView: View {
 
     private func repoHeader(_ group: RepoGroup) -> some View {
         let isCollapsed = collapsed.contains(group.id)
-        return HStack(spacing: 8) {
-            Button {
-                withAnimation(.easeInOut(duration: 0.15)) {
-                    if isCollapsed { collapsed.remove(group.id) }
-                    else { collapsed.insert(group.id) }
-                }
-            } label: {
+        return Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                if isCollapsed { collapsed.remove(group.id) }
+                else { collapsed.insert(group.id) }
+            }
+        } label: {
+            HStack(spacing: 8) {
                 Image(systemName: "chevron.right")
                     .font(.caption.bold())
                     .rotationEffect(.degrees(isCollapsed ? 0 : 90))
                     .foregroundStyle(.secondary)
-                    .frame(width: 14, height: 14)
-                    .contentShape(Rectangle())
-            }
-            .buttonStyle(.plain)
-            .help(isCollapsed ? "Expand" : "Collapse")
 
-            Text(group.repo.nameWithOwner)
-                .font(.subheadline).bold()
-                .foregroundStyle(.secondary)
-                .onTapGesture { NSWorkspace.shared.open(group.repo.pullsURL) }
-                .help("Open \(group.repo.nameWithOwner) pull requests in browser")
-
-            Spacer()
-
-            if group.error == nil {
-                Text("\(group.totalCount)")
-                    .font(.caption)
+                Text(group.repo.nameWithOwner)
+                    .font(.subheadline).bold()
                     .foregroundStyle(.secondary)
-                    .monospacedDigit()
+
+                Spacer()
+
+                if group.error == nil {
+                    Text("\(group.totalCount)")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            }
+            .contentShape(Rectangle())
+            .opacity(dropTargetID == group.id ? 0.5 : 1.0)
+        }
+        .buttonStyle(.plain)
+        .help("Click to collapse · Right-click to open in browser")
+        .contextMenu {
+            Button("Open \(group.repo.nameWithOwner) in Browser") {
+                NSWorkspace.shared.open(group.repo.pullsURL)
             }
         }
+    }
+
+    @discardableResult
+    private func handleDrop(items: [String], target: RepoGroup) -> Bool {
+        guard let sourceName = items.first,
+              let sourceIdx = store.repos.firstIndex(where: { $0.nameWithOwner == sourceName }),
+              let destIdx = store.repos.firstIndex(where: { $0.id == target.repo.id }),
+              sourceIdx != destIdx
+        else { return false }
+        let toOffset = sourceIdx < destIdx ? destIdx + 1 : destIdx
+        store.move(fromOffsets: IndexSet(integer: sourceIdx), toOffset: toOffset)
+        return true
     }
 
     private func errorRow(_ message: String, repo: TrackedRepo) -> some View {

--- a/Sources/Gowi/UI/PRListView.swift
+++ b/Sources/Gowi/UI/PRListView.swift
@@ -12,7 +12,7 @@ struct PRListView: View {
     var body: some View {
         List {
             ForEach(groups) { group in
-                DisclosureGroup(
+                Section(
                     isExpanded: Binding(
                         get: { !collapsed.contains(group.id) },
                         set: { expanded in
@@ -24,17 +24,8 @@ struct PRListView: View {
                     )
                 ) {
                     body(for: group)
-                } label: {
+                } header: {
                     repoHeader(group)
-                        .onTapGesture {
-                            withAnimation(.easeInOut(duration: 0.15)) {
-                                if collapsed.contains(group.id) {
-                                    collapsed.remove(group.id)
-                                } else {
-                                    collapsed.insert(group.id)
-                                }
-                            }
-                        }
                 }
             }
             .onMove { model.moveRepo(fromOffsets: $0, toOffset: $1) }
@@ -79,21 +70,33 @@ struct PRListView: View {
     }
 
     private func repoHeader(_ group: RepoGroup) -> some View {
-        HStack(spacing: 8) {
-            Text(group.repo.nameWithOwner)
-                .font(.subheadline).bold()
-                .foregroundStyle(.secondary)
-
-            Spacer()
-
-            if group.error == nil {
-                Text("\(group.totalCount)")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .monospacedDigit()
+        let isCollapsed = collapsed.contains(group.id)
+        return Button {
+            withAnimation(.easeInOut(duration: 0.15)) {
+                if isCollapsed { collapsed.remove(group.id) }
+                else { collapsed.insert(group.id) }
             }
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "chevron.right")
+                    .font(.caption.bold())
+                    .rotationEffect(.degrees(isCollapsed ? 0 : 90))
+                    .foregroundStyle(.secondary)
+                Text(group.repo.nameWithOwner)
+                    .font(.headline)
+                    .foregroundStyle(.primary)
+                Spacer()
+                if group.error == nil {
+                    Text("\(group.totalCount)")
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                        .monospacedDigit()
+                }
+            }
+            .padding(.vertical, 4)
+            .contentShape(Rectangle())
         }
-        .contentShape(Rectangle())
+        .buttonStyle(.plain)
         .help("Right-click to open in browser")
         .contextMenu {
             Button("Open \(group.repo.nameWithOwner) in Browser") {

--- a/Sources/Gowi/UI/PRListView.swift
+++ b/Sources/Gowi/UI/PRListView.swift
@@ -1,6 +1,17 @@
 import SwiftUI
 import AppKit
 
+/// Hides DisclosureGroup's built-in system chevron so we can supply our own
+/// animated one. The List still treats this as an outline group for drag-and-drop.
+private struct NoSystemChevronStyle: DisclosureGroupStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+        if configuration.isExpanded {
+            configuration.content
+        }
+    }
+}
+
 struct PRListView: View {
     let groups: [RepoGroup]
     let onRetry: (TrackedRepo?) -> Void
@@ -12,7 +23,7 @@ struct PRListView: View {
     var body: some View {
         List {
             ForEach(groups) { group in
-                Section(
+                DisclosureGroup(
                     isExpanded: Binding(
                         get: { !collapsed.contains(group.id) },
                         set: { expanded in
@@ -24,9 +35,10 @@ struct PRListView: View {
                     )
                 ) {
                     body(for: group)
-                } header: {
+                } label: {
                     repoHeader(group)
                 }
+                .disclosureGroupStyle(NoSystemChevronStyle())
             }
             .onMove { model.moveRepo(fromOffsets: $0, toOffset: $1) }
         }
@@ -34,21 +46,26 @@ struct PRListView: View {
         .refreshable { await onPullRefresh() }
     }
 
+    private static let childRowInsets = EdgeInsets(top: 2, leading: -20, bottom: 2, trailing: 4)
+
     @ViewBuilder
     private func body(for group: RepoGroup) -> some View {
         if let error = group.error {
             errorRow(error, repo: group.repo)
+                .listRowInsets(Self.childRowInsets)
         } else if group.pullRequests.isEmpty {
             Text("No open PRs")
                 .font(.callout)
                 .foregroundStyle(.secondary)
+                .listRowInsets(Self.childRowInsets)
         } else {
             ForEach(group.pullRequests) { pr in
                 PRRow(pr: pr)
-                    .listRowInsets(EdgeInsets(top: 2, leading: 4, bottom: 2, trailing: 4))
+                    .listRowInsets(Self.childRowInsets)
             }
             if group.totalCount > group.pullRequests.count {
                 moreFooter(for: group)
+                    .listRowInsets(Self.childRowInsets)
             }
         }
     }
@@ -71,32 +88,32 @@ struct PRListView: View {
 
     private func repoHeader(_ group: RepoGroup) -> some View {
         let isCollapsed = collapsed.contains(group.id)
-        return Button {
-            withAnimation(.easeInOut(duration: 0.15)) {
-                if isCollapsed { collapsed.remove(group.id) }
-                else { collapsed.insert(group.id) }
-            }
-        } label: {
-            HStack(spacing: 6) {
+        return HStack(spacing: 6) {
+            Button {
+                withAnimation(.easeInOut(duration: 0.15)) {
+                    if isCollapsed { collapsed.remove(group.id) }
+                    else { collapsed.insert(group.id) }
+                }
+            } label: {
                 Image(systemName: "chevron.right")
                     .font(.caption.bold())
                     .rotationEffect(.degrees(isCollapsed ? 0 : 90))
                     .foregroundStyle(.secondary)
-                Text(group.repo.nameWithOwner)
-                    .font(.headline)
-                    .foregroundStyle(.primary)
-                Spacer()
-                if group.error == nil {
-                    Text("\(group.totalCount)")
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                        .monospacedDigit()
-                }
             }
-            .padding(.vertical, 4)
-            .contentShape(Rectangle())
+            .buttonStyle(.plain)
+
+            Text(group.repo.nameWithOwner)
+                .font(.headline)
+                .foregroundStyle(.primary)
+            Spacer()
+            if group.error == nil {
+                Text("\(group.totalCount)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .monospacedDigit()
+            }
         }
-        .buttonStyle(.plain)
+        .padding(.vertical, 4)
         .help("Right-click to open in browser")
         .contextMenu {
             Button("Open \(group.repo.nameWithOwner) in Browser") {

--- a/Sources/Gowi/UI/PRListView.swift
+++ b/Sources/Gowi/UI/PRListView.swift
@@ -26,6 +26,15 @@ struct PRListView: View {
                     body(for: group)
                 } label: {
                     repoHeader(group)
+                        .onTapGesture {
+                            withAnimation(.easeInOut(duration: 0.15)) {
+                                if collapsed.contains(group.id) {
+                                    collapsed.remove(group.id)
+                                } else {
+                                    collapsed.insert(group.id)
+                                }
+                            }
+                        }
                 }
             }
             .onMove { model.moveRepo(fromOffsets: $0, toOffset: $1) }


### PR DESCRIPTION
## Summary

- **Header misclick fix**: the entire repo header row is now a single collapse/expand button (full-width hit area). The old setup had a 14×14 chevron button beside a Text tap gesture for opening the repo URL — misclicking the name would open an unwanted browser tab. Right-click → \"Open in Browser\" via context menu replaces the inline tap gesture.
- **Drag-to-reorder in popover/main window**: repo section headers in `PRListView` are now draggable. Drop one header above/below another to reorder repos. Calls the existing `store.move(fromOffsets:toOffset:)` so order persists to UserDefaults and survives relaunches.
- **Settings drag affordance**: added a `line.3.horizontal` grip icon to each row in Settings → Repositories to surface the existing `.onMove` drag-to-reorder that was already wired but invisible.
- **Docs**: added testing guidelines to `CLAUDE.md` covering the direct-source test target structure and the no-`@testable`-import rule.

## Test plan

- [x] Click anywhere across a repo header row → collapses/expands, no browser tab opens
- [x] Right-click a repo header → \"Open \<repo\> in Browser\" appears and opens the correct URL
- [x] In the menu bar popover (≥2 repos), drag a repo header above/below another → order changes immediately and persists after relaunch
- [x] Same drag-and-drop works in the main window `PRListView`
- [x] Settings → Repositories shows the grip icon; dragging rows there still reorders correctly
- [x] `xcodebuild -scheme gowi -destination 'platform=macOS' test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)