### PR TITLE
fix: cache staleness indicator, silent token revocation, and PRCache logging

### DIFF
--- a/Sources/Gowi/AppModel.swift
+++ b/Sources/Gowi/AppModel.swift
@@ -26,6 +26,8 @@ final class AppModel: ObservableObject {
     @Published var lastRefresh: Date?
     @Published var rateLimitWarning: Bool = false
     @Published var samlAuthURL: URL?
+    @Published var isShowingCachedData: Bool = false
+    @Published var tokenRevoked: Bool = false
 
     let github: GitHubClient
     private let auth: AuthService
@@ -49,6 +51,7 @@ final class AppModel: ObservableObject {
                 guard let self else { return }
                 switch newState {
                 case .signedIn:
+                    self.tokenRevoked = false
                     Task { await self.refreshViewer() }
                     self.loadCacheIfNeeded()
                     self.refresh()
@@ -56,6 +59,7 @@ final class AppModel: ObservableObject {
                 case .signedOut, .failed, .awaitingUserCode:
                     self.viewer = nil
                     self.state = .signedOut
+                    self.isShowingCachedData = false
                     self.refreshTask?.cancel()
                     self.tickTask?.cancel()
                     self.rateLimitWarning = false
@@ -181,16 +185,22 @@ final class AppModel: ObservableObject {
             }
 
             state = .loaded(groups)
+            isShowingCachedData = false
             lastRefresh = Date()
             notifications.process(groups: groups)
             PRCache.shared.save(groups)
         } catch GitHubError.unauthorized {
+            tokenRevoked = true
             auth.signOut()
         } catch GitHubError.samlRequired(let url) {
             samlAuthURL = url
         } catch {
             let msg = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-            if case .loaded = state {} else { state = .error(msg) }
+            if case .loaded = state {
+                isShowingCachedData = true
+            } else {
+                state = .error(msg)
+            }
             lastError = msg
         }
     }
@@ -206,6 +216,7 @@ final class AppModel: ObservableObject {
                 PRCache.shared.save(groups)
             }
         } catch GitHubError.unauthorized {
+            tokenRevoked = true
             auth.signOut()
         } catch GitHubError.samlRequired(let url) {
             samlAuthURL = url
@@ -225,6 +236,7 @@ final class AppModel: ObservableObject {
         guard case .signedOut = state else { return }
         if let cached = PRCache.shared.load(), !cached.isEmpty {
             state = .loaded(cached)
+            isShowingCachedData = true
         }
     }
 

--- a/Sources/Gowi/PRCache.swift
+++ b/Sources/Gowi/PRCache.swift
@@ -1,4 +1,7 @@
 import Foundation
+import OSLog
+
+private let logger = Logger(subsystem: "com.lloydmajor.gowi", category: "PRCache")
 
 struct PRCache {
     static let shared = PRCache()
@@ -25,12 +28,23 @@ struct PRCache {
     }()
 
     func load() -> [RepoGroup]? {
-        guard let url, let data = try? Data(contentsOf: url) else { return nil }
-        return try? decoder.decode([RepoGroup].self, from: data)
+        guard let url else { return nil }
+        do {
+            let data = try Data(contentsOf: url)
+            return try decoder.decode([RepoGroup].self, from: data)
+        } catch {
+            logger.error("Cache load failed: \(error.localizedDescription)")
+            return nil
+        }
     }
 
     func save(_ groups: [RepoGroup]) {
-        guard let url, let data = try? encoder.encode(groups) else { return }
-        try? data.write(to: url, options: .atomic)
+        guard let url else { return }
+        do {
+            let data = try encoder.encode(groups)
+            try data.write(to: url, options: .atomic)
+        } catch {
+            logger.error("Cache save failed: \(error.localizedDescription)")
+        }
     }
 }

--- a/Sources/Gowi/UI/MainWindow.swift
+++ b/Sources/Gowi/UI/MainWindow.swift
@@ -30,11 +30,19 @@ struct MainWindow: View {
     @ViewBuilder
     private var content: some View {
         if auth.state != .signedIn {
-            SignInView()
+            VStack(spacing: 0) {
+                if model.tokenRevoked {
+                    tokenRevokedBanner
+                }
+                SignInView()
+            }
         } else if store.repos.isEmpty {
             noReposState
         } else {
             VStack(spacing: 0) {
+                if model.isShowingCachedData && !model.isRefreshing {
+                    cachedDataBanner
+                }
                 if let authURL = model.samlAuthURL {
                     samlBanner(url: authURL)
                 }
@@ -94,6 +102,49 @@ struct MainWindow: View {
                 .help("Settings")
             }
         }
+    }
+
+    // MARK: - token revoked banner
+
+    private var tokenRevokedBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "key.slash")
+                .foregroundStyle(.red)
+            Text("You were signed out because your GitHub token was revoked.")
+                .font(.callout)
+                .foregroundStyle(.primary)
+            Spacer()
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background(Color.red.opacity(0.10))
+        .overlay(alignment: .bottom) { Divider() }
+    }
+
+    // MARK: - cached data banner
+
+    private var cachedDataBanner: some View {
+        HStack(spacing: 8) {
+            Image(systemName: "clock.arrow.circlepath")
+                .foregroundStyle(.secondary)
+            if let last = model.lastRefresh {
+                Text("Showing cached data — last refreshed \(last, format: .relative(presentation: .named))")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            } else {
+                Text("Showing cached data")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer()
+            Button("Retry") { model.refresh() }
+                .font(.caption)
+                .buttonStyle(.borderless)
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 6)
+        .background(Color(nsColor: .controlBackgroundColor))
+        .overlay(alignment: .bottom) { Divider() }
     }
 
     // MARK: - SAML banner

--- a/Sources/Gowi/UI/MenuBarRoot.swift
+++ b/Sources/Gowi/UI/MenuBarRoot.swift
@@ -126,29 +126,47 @@ struct MenuBarRoot: View {
     }
 
     private var footer: some View {
-        HStack(spacing: 8) {
-            if let last = model.lastRefresh {
-                Text("Refreshed \(last, format: .relative(presentation: .named))")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            } else {
-                Text("—").font(.caption).foregroundStyle(.secondary)
+        VStack(spacing: 0) {
+            if model.isShowingCachedData && !model.isRefreshing {
+                HStack(spacing: 6) {
+                    Image(systemName: "clock.arrow.circlepath")
+                        .font(.caption2)
+                    Text("Cached data")
+                        .font(.caption2)
+                    Spacer()
+                    Button("Retry") { model.refresh() }
+                        .font(.caption2)
+                        .buttonStyle(.borderless)
+                }
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 4)
+                Divider()
             }
-            Spacer()
-            Button { openSettings() } label: {
-                Image(systemName: "gearshape")
-            }
-            .buttonStyle(.borderless)
-            .help("Settings")
+            HStack(spacing: 8) {
+                if let last = model.lastRefresh {
+                    Text("Refreshed \(last, format: .relative(presentation: .named))")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                } else {
+                    Text("—").font(.caption).foregroundStyle(.secondary)
+                }
+                Spacer()
+                Button { openSettings() } label: {
+                    Image(systemName: "gearshape")
+                }
+                .buttonStyle(.borderless)
+                .help("Settings")
 
-            Button { NSApp.terminate(nil) } label: {
-                Image(systemName: "power")
+                Button { NSApp.terminate(nil) } label: {
+                    Image(systemName: "power")
+                }
+                .buttonStyle(.borderless)
+                .help("Quit gowi")
             }
-            .buttonStyle(.borderless)
-            .help("Quit gowi")
+            .padding(.horizontal, 12)
+            .padding(.vertical, 6)
         }
-        .padding(.horizontal, 12)
-        .padding(.vertical, 6)
     }
 
     // MARK: - helpers


### PR DESCRIPTION
- AppModel gains isShowingCachedData (set on cache load and on network error while cached data is displayed; cleared on live refresh success) and tokenRevoked (set on 401 sign-out; cleared on next sign-in)
- MainWindow shows a "Cached data — Retry" banner when isShowingCachedData and a red banner explaining token revocation above SignInView
- MenuBarRoot footer shows a compact "Cached data — Retry" row in the same conditions
- PRCache switches from try? to do/catch with OSLog so disk errors surface in Console.app instead of being silently swallowed