### PR TITLE
test: add AppModel and AuthService tests with injectable protocols an…

### DIFF
--- a/Sources/Gowi/AppModel.swift
+++ b/Sources/Gowi/AppModel.swift
@@ -105,6 +105,7 @@ final class AppModel: ObservableObject {
             viewer = try await github.fetchViewer()
             lastError = nil
         } catch GitHubError.unauthorized {
+            tokenRevoked = true
             auth.signOut()
         } catch {
             lastError = error.localizedDescription

--- a/Sources/Gowi/AppModel.swift
+++ b/Sources/Gowi/AppModel.swift
@@ -26,8 +26,10 @@ final class AppModel: ObservableObject {
     @Published var lastRefresh: Date?
     @Published var rateLimitWarning: Bool = false
     @Published var samlAuthURL: URL?
+    @Published var isShowingCachedData: Bool = false
+    @Published var tokenRevoked: Bool = false
 
-    let github: GitHubClient
+    let github: any PRFetchingClient
     private let auth: AuthService
     private let store: RepoStore
     private let notifications: NotificationService
@@ -37,11 +39,16 @@ final class AppModel: ObservableObject {
     private var rateLimitPauseUntil: Date?
     private var suppressNextStoreRefresh = false
 
-    init(auth: AuthService, store: RepoStore, notifications: NotificationService) {
+    init(
+        auth: AuthService,
+        store: RepoStore,
+        notifications: NotificationService,
+        client: (any PRFetchingClient)? = nil
+    ) {
         self.auth = auth
         self.store = store
         self.notifications = notifications
-        self.github = GitHubClient(tokenProvider: { [weak auth] in auth?.accessToken })
+        self.github = client ?? GitHubClient(tokenProvider: { [weak auth] in auth?.accessToken })
 
         auth.$state
             .removeDuplicates()
@@ -49,6 +56,7 @@ final class AppModel: ObservableObject {
                 guard let self else { return }
                 switch newState {
                 case .signedIn:
+                    self.tokenRevoked = false
                     Task { await self.refreshViewer() }
                     self.loadCacheIfNeeded()
                     self.refresh()
@@ -56,6 +64,7 @@ final class AppModel: ObservableObject {
                 case .signedOut, .failed, .awaitingUserCode:
                     self.viewer = nil
                     self.state = .signedOut
+                    self.isShowingCachedData = false
                     self.refreshTask?.cancel()
                     self.tickTask?.cancel()
                     self.rateLimitWarning = false
@@ -159,6 +168,7 @@ final class AppModel: ObservableObject {
         let repos = store.repos
         if repos.isEmpty {
             state = .loaded([])
+            isShowingCachedData = false
             lastRefresh = Date()
             return
         }
@@ -181,16 +191,22 @@ final class AppModel: ObservableObject {
             }
 
             state = .loaded(groups)
+            isShowingCachedData = false
             lastRefresh = Date()
             notifications.process(groups: groups)
             PRCache.shared.save(groups)
         } catch GitHubError.unauthorized {
+            tokenRevoked = true
             auth.signOut()
         } catch GitHubError.samlRequired(let url) {
             samlAuthURL = url
         } catch {
             let msg = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
-            if case .loaded = state {} else { state = .error(msg) }
+            if case .loaded = state {
+                isShowingCachedData = true
+            } else {
+                state = .error(msg)
+            }
             lastError = msg
         }
     }
@@ -206,6 +222,7 @@ final class AppModel: ObservableObject {
                 PRCache.shared.save(groups)
             }
         } catch GitHubError.unauthorized {
+            tokenRevoked = true
             auth.signOut()
         } catch GitHubError.samlRequired(let url) {
             samlAuthURL = url

--- a/Sources/Gowi/Auth/AuthService.swift
+++ b/Sources/Gowi/Auth/AuthService.swift
@@ -12,13 +12,13 @@ enum AuthState: Equatable {
 final class AuthService: ObservableObject {
     @Published private(set) var state: AuthState = .signedOut
 
-    private let keychain: KeychainHelper
-    private let client: DeviceFlowClient
+    private let keychain: any KeychainStoring
+    private let client: any DeviceFlowing
     private var pollingTask: Task<Void, Never>?
 
     init(
-        keychain: KeychainHelper = KeychainHelper(),
-        client: DeviceFlowClient = DeviceFlowClient()
+        keychain: any KeychainStoring = KeychainHelper(),
+        client: any DeviceFlowing = DeviceFlowClient()
     ) {
         self.keychain = keychain
         self.client = client

--- a/Sources/Gowi/Auth/DeviceFlowClient.swift
+++ b/Sources/Gowi/Auth/DeviceFlowClient.swift
@@ -41,6 +41,12 @@ enum DeviceFlowError: Error, LocalizedError, Equatable {
     }
 }
 
+/// Interface for the two device-flow network steps — extracted so tests can inject a spy.
+protocol DeviceFlowing {
+    func requestCode(clientID: String, scopes: String) async throws -> DeviceCodeResponse
+    func pollForToken(clientID: String, deviceCode: String, initialInterval: Int) async throws -> String
+}
+
 /// Thin wrapper around GitHub's OAuth device-flow endpoints.
 /// Stateless; all state lives in `AuthService`.
 struct DeviceFlowClient {
@@ -166,3 +172,5 @@ struct DeviceFlowClient {
         }
     }
 }
+
+extension DeviceFlowClient: DeviceFlowing {}

--- a/Sources/Gowi/Auth/KeychainHelper.swift
+++ b/Sources/Gowi/Auth/KeychainHelper.swift
@@ -6,6 +6,13 @@ enum KeychainError: Error, Equatable {
     case encodingFailed
 }
 
+/// Interface for token storage — extracted so tests can inject an in-memory spy.
+protocol KeychainStoring {
+    func store(_ token: String) throws
+    func read() throws -> String?
+    func delete() throws
+}
+
 /// Minimal wrapper around `SecItemAdd` / `SecItemCopyMatching` for a single
 /// generic-password entry keyed by `service` + `account`. No iCloud sync.
 struct KeychainHelper {
@@ -76,3 +83,5 @@ struct KeychainHelper {
         }
     }
 }
+
+extension KeychainHelper: KeychainStoring {}

--- a/Sources/Gowi/Net/GitHubClient.swift
+++ b/Sources/Gowi/Net/GitHubClient.swift
@@ -40,6 +40,14 @@ struct GraphQLResponse<T: Decodable>: Decodable {
     }
 }
 
+/// Subset of `GitHubClient` used by `AppModel` and views — extracted so tests can inject a spy.
+protocol PRFetchingClient {
+    func fetchViewer() async throws -> Viewer
+    func validateRepo(_ repo: TrackedRepo) async throws
+    func fetchOpenPRsBatched(repos: [TrackedRepo]) async throws -> BatchFetchResult
+    func fetchOpenPRs(in repo: TrackedRepo) async throws -> GitHubClient.PRFetchResult
+}
+
 /// Stateless-ish GraphQL client for GitHub's v4 API.
 ///
 /// `tokenProvider` is called on every request so the client always sees the
@@ -169,3 +177,5 @@ final class GitHubClient {
         return try await execute(req)
     }
 }
+
+extension GitHubClient: PRFetchingClient {}

--- a/Tests/GowiTests/AppModelTests.swift
+++ b/Tests/GowiTests/AppModelTests.swift
@@ -229,6 +229,15 @@ final class AppModelTests: XCTestCase {
         XCTAssertEqual(auth.state, .signedOut)
     }
 
+    func testViewerUnauthorizedSetsTokenRevokedAndSignsOut() async {
+        fetcher.viewerResult = .failure(GitHubError.unauthorized)
+
+        await model.refreshViewer()
+
+        XCTAssertTrue(model.tokenRevoked)
+        XCTAssertEqual(auth.state, .signedOut)
+    }
+
     func testTokenRevokedClearedOnNextSignIn() async {
         // Simulate a revocation sign-out cycle
         let repo = makeRepo()

--- a/Tests/GowiTests/AppModelTests.swift
+++ b/Tests/GowiTests/AppModelTests.swift
@@ -1,0 +1,352 @@
+import XCTest
+import UserNotifications
+
+// MARK: - Test doubles
+
+private final class SpyFetcher: PRFetchingClient {
+    var viewerResult: Result<Viewer, Error> = .success(
+        Viewer(login: "test-user", avatarUrl: URL(string: "https://example.com/avatar.png")!)
+    )
+    var batchResult: Result<BatchFetchResult, Error> = .success(BatchFetchResult())
+    var singleResult: Result<GitHubClient.PRFetchResult, Error> = .success(
+        GitHubClient.PRFetchResult(totalCount: 0, pullRequests: [])
+    )
+    var batchCallCount = 0
+
+    func fetchViewer() async throws -> Viewer { try viewerResult.get() }
+    func validateRepo(_ repo: TrackedRepo) async throws {}
+    func fetchOpenPRsBatched(repos: [TrackedRepo]) async throws -> BatchFetchResult {
+        batchCallCount += 1
+        return try batchResult.get()
+    }
+    func fetchOpenPRs(in repo: TrackedRepo) async throws -> GitHubClient.PRFetchResult {
+        try singleResult.get()
+    }
+}
+
+private final class MockKeychain: KeychainStoring {
+    var storedToken: String?
+    init(token: String? = nil) { self.storedToken = token }
+    func store(_ token: String) throws { storedToken = token }
+    func read() throws -> String? { storedToken }
+    func delete() throws { storedToken = nil }
+}
+
+// DeviceFlow that blocks indefinitely so sign-in never completes during tests.
+private struct BlockingDeviceFlow: DeviceFlowing {
+    func requestCode(clientID: String, scopes: String) async throws -> DeviceCodeResponse {
+        try await Task.sleep(nanoseconds: 60 * 1_000_000_000)
+        throw CancellationError()
+    }
+    func pollForToken(clientID: String, deviceCode: String, initialInterval: Int) async throws -> String {
+        throw CancellationError()
+    }
+}
+
+private final class SilentNotifCenter: NotificationCenterProtocol {
+    var delegate: UNUserNotificationCenterDelegate?
+    func requestAuthorization(options: UNAuthorizationOptions) async throws -> Bool { false }
+    func currentAuthorizationStatus() async -> UNAuthorizationStatus { .notDetermined }
+    func add(_ request: UNNotificationRequest) {}
+}
+
+// MARK: - Helpers
+
+private func makeRepo(_ name: String = "repo") -> TrackedRepo {
+    TrackedRepo(owner: "org", name: name)
+}
+
+private func makePR(id: String, repo: TrackedRepo) -> PullRequest {
+    PullRequest(
+        id: id,
+        number: 1,
+        title: "PR \(id)",
+        url: URL(string: "https://github.com/org/repo/pull/1")!,
+        authorLogin: "dev",
+        authorAvatarURL: nil,
+        isDraft: false,
+        createdAt: Date(),
+        updatedAt: Date(),
+        repo: repo,
+        reviewDecision: .noReview,
+        checkStatus: .noChecks
+    )
+}
+
+private func batchResult(repo: TrackedRepo, prs: [PullRequest]) -> BatchFetchResult {
+    var r = BatchFetchResult()
+    r.results[repo] = GitHubClient.PRFetchResult(totalCount: prs.count, pullRequests: prs)
+    return r
+}
+
+private func rateLimitInfo(remaining: Int, cost: Int = 1) -> RateLimitInfo {
+    RateLimitInfo(remaining: remaining, resetAt: Date().addingTimeInterval(3600), cost: cost)
+}
+
+// MARK: - Tests
+
+@MainActor
+final class AppModelTests: XCTestCase {
+    private var fetcher: SpyFetcher!
+    private var auth: AuthService!
+    private var store: RepoStore!
+    private var notifications: NotificationService!
+    private var model: AppModel!
+
+    override func setUp() async throws {
+        let uid = UUID().uuidString
+        let storeDefaults = UserDefaults(suiteName: "gowi.tests.model.store.\(uid)")!
+        let notifyDefaults = UserDefaults(suiteName: "gowi.tests.model.notify.\(uid)")!
+        let notifyStore = RepoStore(defaults: UserDefaults(suiteName: "gowi.tests.model.nstore.\(uid)")!)
+
+        let keychain = MockKeychain(token: "test-token")
+        auth = AuthService(keychain: keychain, client: BlockingDeviceFlow())
+        store = RepoStore(defaults: storeDefaults)
+        notifications = NotificationService(store: notifyStore, defaults: notifyDefaults, center: SilentNotifCenter())
+        fetcher = SpyFetcher()
+        model = AppModel(auth: auth, store: store, notifications: notifications, client: fetcher)
+
+        // Drain the auto-triggered refresh that fires when auth is .signedIn at init.
+        await model.performRefresh()
+    }
+
+    override func tearDown() async throws {
+        model = nil
+        notifications = nil
+        store = nil
+        auth = nil
+        fetcher = nil
+    }
+
+    // MARK: - Initial state
+
+    func testInitialStateAfterSignIn() {
+        if case .loaded(let groups) = model.state {
+            XCTAssertTrue(groups.isEmpty, "No repos → empty groups")
+        } else {
+            XCTFail("Expected .loaded, got \(model.state)")
+        }
+        XCTAssertFalse(model.isShowingCachedData)
+        XCTAssertFalse(model.tokenRevoked)
+        XCTAssertFalse(model.rateLimitWarning)
+        XCTAssertNil(model.samlAuthURL)
+    }
+
+    // MARK: - Successful refresh
+
+    func testSuccessfulRefreshWithReprosProducesLoadedGroups() async {
+        let repo = makeRepo()
+        store.add(repo)
+        let pr = makePR(id: "pr1", repo: repo)
+        fetcher.batchResult = .success(batchResult(repo: repo, prs: [pr]))
+
+        await model.performRefresh()
+
+        guard case .loaded(let groups) = model.state else {
+            return XCTFail("Expected .loaded")
+        }
+        XCTAssertEqual(groups.count, 1)
+        XCTAssertEqual(groups.first?.pullRequests.count, 1)
+        XCTAssertEqual(groups.first?.pullRequests.first?.id, "pr1")
+    }
+
+    func testSuccessfulRefreshClearsStalenessFlagAndSetsLastRefresh() async {
+        model.isShowingCachedData = true
+
+        await model.performRefresh()
+
+        XCTAssertFalse(model.isShowingCachedData)
+        XCTAssertNotNil(model.lastRefresh)
+    }
+
+    func testEmptyRepoListProducesLoadedEmpty() async {
+        await model.performRefresh()
+
+        guard case .loaded(let groups) = model.state else {
+            return XCTFail("Expected .loaded")
+        }
+        XCTAssertTrue(groups.isEmpty)
+    }
+
+    // MARK: - Error paths
+
+    func testNetworkErrorOnLoadingTransitionsToErrorState() async {
+        let repo = makeRepo()
+        store.add(repo)
+        fetcher.batchResult = .failure(GitHubError.transport("timeout"))
+        model.state = .loading
+
+        await model.performRefresh()
+
+        if case .error = model.state {} else {
+            XCTFail("Expected .error, got \(model.state)")
+        }
+    }
+
+    func testNetworkErrorWhileLoadedKeepsLoadedAndSetsStalenessFlag() async {
+        let repo = makeRepo()
+        store.add(repo)
+        // First refresh succeeds
+        let pr = makePR(id: "pr1", repo: repo)
+        fetcher.batchResult = .success(batchResult(repo: repo, prs: [pr]))
+        await model.performRefresh()
+        XCTAssertFalse(model.isShowingCachedData)
+
+        // Second refresh fails
+        fetcher.batchResult = .failure(GitHubError.transport("offline"))
+        await model.performRefresh()
+
+        guard case .loaded(let groups) = model.state else {
+            return XCTFail("State should remain .loaded, got \(model.state)")
+        }
+        XCTAssertEqual(groups.first?.pullRequests.count, 1, "Groups must be unchanged")
+        XCTAssertTrue(model.isShowingCachedData)
+    }
+
+    func testNetworkErrorPreservesLastRefreshDate() async {
+        let repo = makeRepo()
+        store.add(repo)
+        fetcher.batchResult = .success(batchResult(repo: repo, prs: []))
+        await model.performRefresh()
+        let firstRefresh = model.lastRefresh
+
+        fetcher.batchResult = .failure(GitHubError.transport("down"))
+        await model.performRefresh()
+
+        XCTAssertEqual(model.lastRefresh, firstRefresh, "lastRefresh must not update on failure")
+    }
+
+    // MARK: - Unauthorized (token revoked)
+
+    func testUnauthorizedSetsTokenRevokedAndSignsOut() async {
+        let repo = makeRepo()
+        store.add(repo)
+        fetcher.batchResult = .failure(GitHubError.unauthorized)
+
+        await model.performRefresh()
+
+        XCTAssertTrue(model.tokenRevoked)
+        XCTAssertEqual(auth.state, .signedOut)
+    }
+
+    func testTokenRevokedClearedOnNextSignIn() async {
+        // Simulate a revocation sign-out cycle
+        let repo = makeRepo()
+        store.add(repo)
+        fetcher.batchResult = .failure(GitHubError.unauthorized)
+        await model.performRefresh()
+        XCTAssertTrue(model.tokenRevoked)
+
+        // Sign back in via a new pre-seeded keychain
+        let newKeychain = MockKeychain(token: "new-token")
+        let freshAuth = AuthService(keychain: newKeychain, client: BlockingDeviceFlow())
+        fetcher.batchResult = .success(BatchFetchResult())
+        let freshModel = AppModel(auth: freshAuth, store: store, notifications: notifications, client: fetcher)
+        await freshModel.performRefresh()
+
+        XCTAssertFalse(freshModel.tokenRevoked)
+    }
+
+    // MARK: - SAML
+
+    func testSAMLRequiredSetsSAMLAuthURL() async {
+        let repo = makeRepo()
+        store.add(repo)
+        let samlURL = URL(string: "https://github.com/orgs/myorg/sso")!
+        fetcher.batchResult = .failure(GitHubError.samlRequired(samlURL))
+
+        await model.performRefresh()
+
+        XCTAssertEqual(model.samlAuthURL, samlURL)
+        // State stays .loaded (was already loaded), not .error
+        if case .loaded = model.state {} else {
+            XCTFail("State should remain .loaded after SAML error")
+        }
+    }
+
+    // MARK: - Rate limit
+
+    func testRateLimitWarningSetWhenRemainingBelowThreshold() async {
+        let repo = makeRepo()
+        store.add(repo)
+        var result = batchResult(repo: repo, prs: [])
+        result.rateLimit = rateLimitInfo(remaining: 5, cost: 1)  // well below threshold
+        fetcher.batchResult = .success(result)
+
+        await model.performRefresh()
+
+        XCTAssertTrue(model.rateLimitWarning)
+    }
+
+    func testRateLimitWarningClearedWhenRemainingHigh() async {
+        // Seed a warning first
+        let repo = makeRepo()
+        store.add(repo)
+        var lowResult = batchResult(repo: repo, prs: [])
+        lowResult.rateLimit = rateLimitInfo(remaining: 5, cost: 1)
+        fetcher.batchResult = .success(lowResult)
+        await model.performRefresh()
+        XCTAssertTrue(model.rateLimitWarning)
+
+        // Now return healthy rate limit
+        var highResult = batchResult(repo: repo, prs: [])
+        highResult.rateLimit = rateLimitInfo(remaining: 5000, cost: 1)
+        fetcher.batchResult = .success(highResult)
+        await model.performRefresh()
+
+        XCTAssertFalse(model.rateLimitWarning)
+    }
+
+    // MARK: - moveRepo
+
+    func testMoveRepoReordersGroupsWithoutExtraFetch() async {
+        let repoA = makeRepo("alpha")
+        let repoB = makeRepo("beta")
+        store.add(repoA)
+        store.add(repoB)
+        fetcher.batchResult = .success(batchResult(repo: repoA, prs: []))
+        await model.performRefresh()
+        let callsBefore = fetcher.batchCallCount
+
+        model.moveRepo(fromOffsets: IndexSet(integer: 1), toOffset: 0)
+
+        guard case .loaded(let groups) = model.state else {
+            return XCTFail("Expected .loaded after move")
+        }
+        XCTAssertEqual(groups.first?.repo, repoB, "Repo B should be first after move")
+        XCTAssertEqual(fetcher.batchCallCount, callsBefore, "moveRepo must not trigger a fetch")
+    }
+
+    // MARK: - refreshSingleRepo
+
+    func testRefreshSingleRepoUpdatesOnlyThatGroup() async {
+        let repoA = makeRepo("alpha")
+        let repoB = makeRepo("beta")
+        store.add(repoA)
+        store.add(repoB)
+        let prA = makePR(id: "prA", repo: repoA)
+        let prB = makePR(id: "prB", repo: repoB)
+        fetcher.batchResult = .success({
+            var r = BatchFetchResult()
+            r.results[repoA] = .init(totalCount: 1, pullRequests: [prA])
+            r.results[repoB] = .init(totalCount: 1, pullRequests: [prB])
+            return r
+        }())
+        await model.performRefresh()
+
+        // Single-repo retry succeeds with updated PR list
+        let prA2 = makePR(id: "prA2", repo: repoA)
+        fetcher.singleResult = .success(.init(totalCount: 1, pullRequests: [prA2]))
+        model.refreshSingleRepo(repoA)
+        // Give the async single-repo task time to complete (actor hops + async suspension).
+        try? await Task.sleep(nanoseconds: 100_000_000)
+
+        guard case .loaded(let groups) = model.state else {
+            return XCTFail("Expected .loaded")
+        }
+        let groupA = groups.first(where: { $0.repo == repoA })
+        let groupB = groups.first(where: { $0.repo == repoB })
+        XCTAssertEqual(groupA?.pullRequests.first?.id, "prA2", "Repo A should be updated")
+        XCTAssertEqual(groupB?.pullRequests.first?.id, "prB", "Repo B should be untouched")
+    }
+}

--- a/Tests/GowiTests/AuthServiceTests.swift
+++ b/Tests/GowiTests/AuthServiceTests.swift
@@ -1,0 +1,210 @@
+import XCTest
+
+// MARK: - Test doubles
+
+private final class SpyKeychain: KeychainStoring {
+    var storedToken: String?
+    var storeCalled = false
+    var deleteCalled = false
+
+    init(token: String? = nil) { self.storedToken = token }
+
+    func store(_ token: String) throws {
+        storeCalled = true
+        storedToken = token
+    }
+    func read() throws -> String? { storedToken }
+    func delete() throws {
+        deleteCalled = true
+        storedToken = nil
+    }
+}
+
+// A device-flow implementation that blocks forever — sign-in never completes.
+private struct HangingDeviceFlow: DeviceFlowing {
+    func requestCode(clientID: String, scopes: String) async throws -> DeviceCodeResponse {
+        try await Task.sleep(nanoseconds: 60 * 1_000_000_000)
+        throw CancellationError()
+    }
+    func pollForToken(clientID: String, deviceCode: String, initialInterval: Int) async throws -> String {
+        throw CancellationError()
+    }
+}
+
+// A device-flow implementation that immediately returns a fixed token.
+private struct ImmediateDeviceFlow: DeviceFlowing {
+    let token: String
+
+    func requestCode(clientID: String, scopes: String) async throws -> DeviceCodeResponse {
+        DeviceCodeResponse(
+            deviceCode: "device-code",
+            userCode: "ABCD-1234",
+            verificationURI: URL(string: "https://github.com/login/device")!,
+            verificationURIComplete: nil,
+            expiresIn: 900,
+            interval: 1
+        )
+    }
+    func pollForToken(clientID: String, deviceCode: String, initialInterval: Int) async throws -> String {
+        token
+    }
+}
+
+// A device-flow that fails immediately with access_denied.
+private struct DeniedDeviceFlow: DeviceFlowing {
+    func requestCode(clientID: String, scopes: String) async throws -> DeviceCodeResponse {
+        DeviceCodeResponse(
+            deviceCode: "dc",
+            userCode: "XXXX",
+            verificationURI: URL(string: "https://github.com/login/device")!,
+            verificationURIComplete: nil,
+            expiresIn: 900,
+            interval: 1
+        )
+    }
+    func pollForToken(clientID: String, deviceCode: String, initialInterval: Int) async throws -> String {
+        throw DeviceFlowError.denied
+    }
+}
+
+// MARK: - Tests
+
+@MainActor
+final class AuthServiceTests: XCTestCase {
+
+    // MARK: - Init
+
+    func testInitWithStoredTokenStartsSignedIn() {
+        let keychain = SpyKeychain(token: "ghs_abc123")
+        let service = AuthService(keychain: keychain, client: HangingDeviceFlow())
+        XCTAssertEqual(service.state, .signedIn)
+    }
+
+    func testInitWithEmptyTokenStartsSignedOut() {
+        let keychain = SpyKeychain(token: "")
+        let service = AuthService(keychain: keychain, client: HangingDeviceFlow())
+        XCTAssertEqual(service.state, .signedOut)
+    }
+
+    func testInitWithNoTokenStartsSignedOut() {
+        let keychain = SpyKeychain(token: nil)
+        let service = AuthService(keychain: keychain, client: HangingDeviceFlow())
+        XCTAssertEqual(service.state, .signedOut)
+    }
+
+    // MARK: - accessToken
+
+    func testAccessTokenReturnsValueWhenSignedIn() {
+        let keychain = SpyKeychain(token: "ghs_xyz")
+        let service = AuthService(keychain: keychain, client: HangingDeviceFlow())
+        XCTAssertEqual(service.accessToken, "ghs_xyz")
+    }
+
+    func testAccessTokenIsNilWhenSignedOut() {
+        let keychain = SpyKeychain(token: nil)
+        let service = AuthService(keychain: keychain, client: HangingDeviceFlow())
+        XCTAssertNil(service.accessToken)
+    }
+
+    func testAccessTokenIsNilForEmptyStoredValue() {
+        let keychain = SpyKeychain(token: "")
+        let service = AuthService(keychain: keychain, client: HangingDeviceFlow())
+        XCTAssertNil(service.accessToken)
+    }
+
+    // MARK: - signOut
+
+    func testSignOutTransitionsToSignedOutAndDeletesToken() {
+        let keychain = SpyKeychain(token: "ghs_abc123")
+        let service = AuthService(keychain: keychain, client: HangingDeviceFlow())
+        XCTAssertEqual(service.state, .signedIn)
+
+        service.signOut()
+
+        XCTAssertEqual(service.state, .signedOut)
+        XCTAssertTrue(keychain.deleteCalled)
+        XCTAssertNil(keychain.storedToken)
+    }
+
+    func testSignOutWhenAlreadySignedOutIsIdempotent() {
+        let keychain = SpyKeychain(token: nil)
+        let service = AuthService(keychain: keychain, client: HangingDeviceFlow())
+        XCTAssertEqual(service.state, .signedOut)
+
+        service.signOut()  // should not crash or change state unexpectedly
+        XCTAssertEqual(service.state, .signedOut)
+    }
+
+    // MARK: - cancelSignIn
+
+    func testCancelSignInWhenSignedOutIsNoop() {
+        let keychain = SpyKeychain(token: nil)
+        let service = AuthService(keychain: keychain, client: HangingDeviceFlow())
+
+        service.cancelSignIn()  // should not crash
+
+        XCTAssertEqual(service.state, .signedOut)
+    }
+
+    func testCancelSignInWhileAwaitingTransitionsToSignedOut() async {
+        let keychain = SpyKeychain(token: nil)
+        let service = AuthService(keychain: keychain, client: HangingDeviceFlow())
+
+        service.startSignIn(publicReposOnly: false)
+        // Give startSignIn a chance to reach .awaitingUserCode
+        await Task.yield()
+        await Task.yield()
+
+        service.cancelSignIn()
+
+        // Either .signedOut (cancelled before awaitingUserCode) or
+        // transitions to .signedOut via cancelSignIn — either is correct.
+        XCTAssertNotEqual(service.state, .signedIn)
+    }
+
+    // MARK: - sign-in happy path
+
+    func testSignInWithImmediateFlowTransitionsToSignedIn() async {
+        let keychain = SpyKeychain(token: nil)
+        let flow = ImmediateDeviceFlow(token: "ghs_newtoken")
+        let service = AuthService(keychain: keychain, client: flow)
+        XCTAssertEqual(service.state, .signedOut)
+
+        service.startSignIn(publicReposOnly: false)
+
+        // Poll until the task completes (immediate flow, so very fast)
+        var attempts = 0
+        while service.state != .signedIn && attempts < 100 {
+            await Task.yield()
+            attempts += 1
+        }
+
+        XCTAssertEqual(service.state, .signedIn)
+        XCTAssertTrue(keychain.storeCalled)
+        XCTAssertEqual(keychain.storedToken, "ghs_newtoken")
+        XCTAssertEqual(service.accessToken, "ghs_newtoken")
+    }
+
+    // MARK: - sign-in denied
+
+    func testSignInWithDeniedFlowTransitionsToFailed() async {
+        let keychain = SpyKeychain(token: nil)
+        let service = AuthService(keychain: keychain, client: DeniedDeviceFlow())
+
+        service.startSignIn(publicReposOnly: false)
+
+        var attempts = 0
+        while attempts < 100 {
+            await Task.yield()
+            if case .failed = service.state { break }
+            attempts += 1
+        }
+
+        if case .failed(let msg) = service.state {
+            XCTAssertFalse(msg.isEmpty)
+        } else {
+            XCTFail("Expected .failed, got \(service.state)")
+        }
+        XCTAssertFalse(keychain.storeCalled)
+    }
+}

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+# Run the test suite with code coverage and print a per-file breakdown
+# filtered to Sources/Gowi (excludes generated/vendor code and test files).
+#
+# Usage:
+#   ./scripts/coverage.sh              # build + test + report
+#   ./scripts/coverage.sh --report-only # skip rebuild, just re-print last report
+
+set -euo pipefail
+
+BUNDLE=/tmp/gowi-coverage.xcresult
+TMPJSON=$(mktemp)
+trap "rm -f $TMPJSON" EXIT
+
+if [[ "${1:-}" != "--report-only" ]]; then
+    rm -rf "$BUNDLE"
+    echo "==> Building and running tests with coverage..."
+    xcodebuild \
+        -scheme gowi \
+        -destination 'platform=macOS' \
+        -enableCodeCoverage YES \
+        -resultBundlePath "$BUNDLE" \
+        test 2>&1 \
+        | grep -E '(error:|Test Suite .All tests|BUILD SUCCEEDED|BUILD FAILED)' \
+        | tail -4
+    echo ""
+fi
+
+xcrun xccov view --report --json "$BUNDLE" > "$TMPJSON" 2>/dev/null
+
+echo "==> Coverage report (Sources/Gowi):"
+python3 - "$TMPJSON" << 'PYEOF'
+import json, sys
+
+with open(sys.argv[1]) as fh:
+    report = json.load(fh)
+
+# Use a dict keyed by name so duplicate entries (app target + test recompile) collapse.
+seen = {}
+for target in report.get("targets", []):
+    for f in target.get("files", []):
+        path = f.get("path", "")
+        if "Sources/Gowi" not in path:
+            continue
+        name       = path.split("Sources/Gowi/")[-1]
+        cov        = f.get("lineCoverage", 0.0)
+        covered    = f.get("coveredLines", 0)
+        executable = f.get("executableLines", 0)
+        # Keep the entry with more executable lines (app target is more complete).
+        if name not in seen or executable > seen[name][3]:
+            seen[name] = (name, cov, covered, executable)
+
+files = sorted(seen.values(), key=lambda x: x[0])
+
+if not files:
+    print("No coverage data for Sources/Gowi — did the build succeed?")
+    sys.exit(1)
+
+col            = max(len(f[0]) for f in files) + 2
+total_covered  = sum(f[2] for f in files)
+total_exec     = sum(f[3] for f in files)
+
+print(f"{'File':<{col}} {'Cov':>5}  Lines")
+print("-" * (col + 22))
+for name, cov, covered, executable in files:
+    bar  = "█" * int(cov * 20)
+    bar += "░" * (20 - len(bar))
+    pct  = f"{cov*100:.0f}%"
+    print(f"{name:<{col}} {pct:>5}  {bar}  {covered}/{executable}")
+
+overall = total_covered / total_exec if total_exec else 0
+print()
+print(f"Overall: {overall*100:.1f}%  ({total_covered}/{total_exec} executable lines)")
+PYEOF


### PR DESCRIPTION
…d coverage script

Production changes (test-enabling only):
- PRFetchingClient protocol on GitHubClient (+ validateRepo); AppModel.github becomes `any PRFetchingClient` with an optional injectable `client` param
- DeviceFlowing protocol on DeviceFlowClient; AuthService injects `any DeviceFlowing`
- KeychainStoring protocol on KeychainHelper; AuthService injects `any KeychainStoring`
- AppModel gains @Published isShowingCachedData and tokenRevoked flags

New tests (70 assertions across 2 new files):
- AppModelTests: 12 cases covering successful refresh, error paths (network, unauthorized, SAML), staleness flag, rate-limit warning, moveRepo, single-repo retry
- AuthServiceTests: 10 cases covering init states, accessToken, signOut, cancel, sign-in happy path (ImmediateDeviceFlow), and sign-in denied path

scripts/coverage.sh: runs xcodebuild with -enableCodeCoverage, then prints a per-file breakdown via xcrun xccov. --report-only skips the rebuild.