### PR TITLE
feature: show PR assignees and filter by assigned-to-me

### DIFF
--- a/Sources/Gowi/AppModel.swift
+++ b/Sources/Gowi/AppModel.swift
@@ -28,6 +28,16 @@ final class AppModel: ObservableObject {
     @Published var samlAuthURL: URL?
     @Published var isShowingCachedData: Bool = false
     @Published var tokenRevoked: Bool = false
+    @Published var showOnlyAssignedToMe: Bool = false
+
+    var filteredGroups: [RepoGroup] {
+        guard case .loaded(let groups) = state else { return [] }
+        guard showOnlyAssignedToMe, let viewerLogin = viewer?.login else { return groups }
+        return groups.map { group in
+            let filtered = group.pullRequests.filter { $0.assignees.contains { $0.login == viewerLogin } }
+            return RepoGroup(repo: group.repo, pullRequests: filtered, totalCount: filtered.count, error: group.error)
+        }
+    }
 
     let github: any PRFetchingClient
     private let auth: AuthService

--- a/Sources/Gowi/Models/PullRequest.swift
+++ b/Sources/Gowi/Models/PullRequest.swift
@@ -33,4 +33,35 @@ struct PullRequest: Identifiable, Codable, Hashable {
     let reviewDecision: ReviewDecision
     let checkStatus: CheckStatus
     let assignees: [UserRef]
+
+    init(
+        id: String, number: Int, title: String, url: URL,
+        authorLogin: String?, authorAvatarURL: URL?, isDraft: Bool,
+        createdAt: Date, updatedAt: Date, repo: TrackedRepo,
+        reviewDecision: ReviewDecision, checkStatus: CheckStatus,
+        assignees: [UserRef]
+    ) {
+        self.id = id; self.number = number; self.title = title; self.url = url
+        self.authorLogin = authorLogin; self.authorAvatarURL = authorAvatarURL
+        self.isDraft = isDraft; self.createdAt = createdAt; self.updatedAt = updatedAt
+        self.repo = repo; self.reviewDecision = reviewDecision; self.checkStatus = checkStatus
+        self.assignees = assignees
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        number = try c.decode(Int.self, forKey: .number)
+        title = try c.decode(String.self, forKey: .title)
+        url = try c.decode(URL.self, forKey: .url)
+        authorLogin = try c.decodeIfPresent(String.self, forKey: .authorLogin)
+        authorAvatarURL = try c.decodeIfPresent(URL.self, forKey: .authorAvatarURL)
+        isDraft = try c.decode(Bool.self, forKey: .isDraft)
+        createdAt = try c.decode(Date.self, forKey: .createdAt)
+        updatedAt = try c.decode(Date.self, forKey: .updatedAt)
+        repo = try c.decode(TrackedRepo.self, forKey: .repo)
+        reviewDecision = try c.decode(ReviewDecision.self, forKey: .reviewDecision)
+        checkStatus = try c.decode(CheckStatus.self, forKey: .checkStatus)
+        assignees = try c.decodeIfPresent([UserRef].self, forKey: .assignees) ?? []
+    }
 }

--- a/Sources/Gowi/Models/PullRequest.swift
+++ b/Sources/Gowi/Models/PullRequest.swift
@@ -1,5 +1,10 @@
 import Foundation
 
+struct UserRef: Codable, Hashable {
+    let login: String
+    let avatarURL: URL?
+}
+
 enum ReviewDecision: String, Codable {
     case approved
     case changesRequested
@@ -27,4 +32,5 @@ struct PullRequest: Identifiable, Codable, Hashable {
     let repo: TrackedRepo
     let reviewDecision: ReviewDecision
     let checkStatus: CheckStatus
+    let assignees: [UserRef]
 }

--- a/Sources/Gowi/Net/BatchFetcher.swift
+++ b/Sources/Gowi/Net/BatchFetcher.swift
@@ -63,7 +63,7 @@ extension GitHubClient {
                     id number title url isDraft createdAt updatedAt
                     author { login avatarUrl }
                     reviewDecision
-                    assignees(first: 5) { nodes { login avatarUrl } }
+                    assignees(first: 25) { nodes { login avatarUrl } }
                     commits(last: 1) { nodes { commit { statusCheckRollup { state } } } }
                   }
                 }

--- a/Sources/Gowi/Net/BatchFetcher.swift
+++ b/Sources/Gowi/Net/BatchFetcher.swift
@@ -63,6 +63,7 @@ extension GitHubClient {
                     id number title url isDraft createdAt updatedAt
                     author { login avatarUrl }
                     reviewDecision
+                    assignees(first: 5) { nodes { login avatarUrl } }
                     commits(last: 1) { nodes { commit { statusCheckRollup { state } } } }
                   }
                 }

--- a/Sources/Gowi/Net/GitHubQueries.swift
+++ b/Sources/Gowi/Net/GitHubQueries.swift
@@ -82,8 +82,16 @@ extension GitHubClient {
         let author: Author?
         let reviewDecision: String?
         let commits: CommitsContainer?
+        let assignees: AssigneesContainer?
 
         struct Author: Decodable {
+            let login: String
+            let avatarUrl: URL?
+        }
+        struct AssigneesContainer: Decodable {
+            let nodes: [AssigneeNode]
+        }
+        struct AssigneeNode: Decodable {
             let login: String
             let avatarUrl: URL?
         }
@@ -117,6 +125,7 @@ extension GitHubClient {
                 updatedAt
                 author { login avatarUrl }
                 reviewDecision
+                assignees(first: 5) { nodes { login avatarUrl } }
                 commits(last: 1) {
                   nodes { commit { statusCheckRollup { state } } }
                 }
@@ -156,7 +165,8 @@ enum PRMapper {
             updatedAt: w.updatedAt,
             repo: repo,
             reviewDecision: mapReview(w.reviewDecision),
-            checkStatus: mapChecks(w.commits?.nodes.first?.commit.statusCheckRollup?.state)
+            checkStatus: mapChecks(w.commits?.nodes.first?.commit.statusCheckRollup?.state),
+            assignees: w.assignees?.nodes.map { UserRef(login: $0.login, avatarURL: $0.avatarUrl) } ?? []
         )
     }
 

--- a/Sources/Gowi/Net/GitHubQueries.swift
+++ b/Sources/Gowi/Net/GitHubQueries.swift
@@ -125,7 +125,7 @@ extension GitHubClient {
                 updatedAt
                 author { login avatarUrl }
                 reviewDecision
-                assignees(first: 5) { nodes { login avatarUrl } }
+                assignees(first: 25) { nodes { login avatarUrl } }
                 commits(last: 1) {
                   nodes { commit { statusCheckRollup { state } } }
                 }

--- a/Sources/Gowi/Testing/UITestingSupport.swift
+++ b/Sources/Gowi/Testing/UITestingSupport.swift
@@ -232,7 +232,8 @@ private final class UITestPRFetcher: PRFetchingClient {
                 updatedAt: updatedAt,
                 repo: repo,
                 reviewDecision: review,
-                checkStatus: check
+                checkStatus: check,
+                assignees: []
             )
         }
     }

--- a/Sources/Gowi/UI/MainWindow.swift
+++ b/Sources/Gowi/UI/MainWindow.swift
@@ -51,13 +51,14 @@ struct MainWindow: View {
                     ProgressView("Loading…")
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                         .accessibilityIdentifier(AccessibilityID.Main.loading)
-                case .loaded(let groups):
-                    let hasErrors = groups.contains { $0.error != nil }
-                    if !hasErrors && (groups.isEmpty || totalPRs(groups) == 0) {
+                case .loaded:
+                    let filtered = model.filteredGroups
+                    let hasErrors = filtered.contains { $0.error != nil }
+                    if !hasErrors && (filtered.isEmpty || totalPRs(filtered) == 0) {
                         allClearState
                     } else {
                         PRListView(
-                            groups: groups,
+                            groups: filtered,
                             onRetry: { repo in
                                 if let repo { model.refreshSingleRepo(repo) } else { model.refresh() }
                             },
@@ -74,6 +75,13 @@ struct MainWindow: View {
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
         if auth.state == .signedIn {
+            ToolbarItem(placement: .primaryAction) {
+                Toggle(isOn: $model.showOnlyAssignedToMe) {
+                    Image(systemName: "person.fill")
+                }
+                .toggleStyle(.button)
+                .help("Show only PRs assigned to me")
+            }
             ToolbarItem(placement: .primaryAction) {
                 Button { model.refresh() } label: {
                     ZStack(alignment: .topTrailing) {

--- a/Sources/Gowi/UI/MenuBarRoot.swift
+++ b/Sources/Gowi/UI/MenuBarRoot.swift
@@ -52,6 +52,13 @@ struct MenuBarRoot: View {
                 .font(.headline)
                 .monospacedDigit()
             Spacer()
+            Toggle(isOn: $model.showOnlyAssignedToMe) {
+                Image(systemName: "person.fill")
+            }
+            .toggleStyle(.button)
+            .buttonStyle(.borderless)
+            .help("Show only PRs assigned to me")
+
             Button { model.refresh() } label: {
                 if model.isRefreshing {
                     ProgressView().controlSize(.small)
@@ -95,8 +102,9 @@ struct MenuBarRoot: View {
             switch model.state {
             case .signedOut, .loading:
                 ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
-            case .loaded(let groups):
-                if totalCount == 0 {
+            case .loaded:
+                let filtered = model.filteredGroups
+                if filtered.reduce(0, { $0 + $1.totalCount }) == 0 {
                     centred {
                         Image(systemName: "checkmark.seal")
                             .font(.largeTitle).foregroundStyle(.green)
@@ -104,7 +112,7 @@ struct MenuBarRoot: View {
                     }
                 } else {
                     PRListView(
-                        groups: groups,
+                        groups: filtered,
                         onRetry: { repo in
                             if let repo { model.refreshSingleRepo(repo) } else { model.refresh() }
                         },
@@ -183,10 +191,7 @@ struct MenuBarRoot: View {
     }
 
     private var totalCount: Int {
-        if case .loaded(let groups) = model.state {
-            return groups.reduce(0) { $0 + $1.totalCount }
-        }
-        return 0
+        model.filteredGroups.reduce(0) { $0 + $1.totalCount }
     }
 
     private func openMainWindow() {

--- a/Sources/Gowi/UI/PRRow.swift
+++ b/Sources/Gowi/UI/PRRow.swift
@@ -21,6 +21,11 @@ struct PRRow: View {
                 .frame(width: 24, height: 24)
                 .clipShape(Circle())
 
+            if !pr.assignees.isEmpty {
+                Divider().frame(maxHeight: 16)
+                assigneeAvatarsView
+            }
+
             VStack(alignment: .leading, spacing: 2) {
                 HStack(spacing: 6) {
                     if pr.isDraft { draftPill }
@@ -58,6 +63,37 @@ struct PRRow: View {
         .help(pr.title)
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier(AccessibilityID.PRRow.id(pr.id))
+    }
+
+    @ViewBuilder
+    private var assigneeAvatarsView: some View {
+        HStack(spacing: 3) {
+            ForEach(Array(pr.assignees.prefix(3)), id: \.login) { assignee in
+                assigneeAvatar(for: assignee)
+            }
+            if pr.assignees.count > 3 {
+                Text("+\(pr.assignees.count - 3)")
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func assigneeAvatar(for user: UserRef) -> some View {
+        Group {
+            if let url = user.avatarURL {
+                AsyncImage(url: url) { image in
+                    image.resizable().scaledToFill()
+                } placeholder: {
+                    Circle().fill(.secondary.opacity(0.2))
+                }
+            } else {
+                Circle().fill(.secondary.opacity(0.2))
+            }
+        }
+        .frame(width: 16, height: 16)
+        .clipShape(Circle())
     }
 
     @ViewBuilder

--- a/Tests/GowiTests/AppModelTests.swift
+++ b/Tests/GowiTests/AppModelTests.swift
@@ -56,7 +56,7 @@ private func makeRepo(_ name: String = "repo") -> TrackedRepo {
     TrackedRepo(owner: "org", name: name)
 }
 
-private func makePR(id: String, repo: TrackedRepo) -> PullRequest {
+private func makePR(id: String, repo: TrackedRepo, assignees: [UserRef] = []) -> PullRequest {
     PullRequest(
         id: id,
         number: 1,
@@ -69,7 +69,8 @@ private func makePR(id: String, repo: TrackedRepo) -> PullRequest {
         updatedAt: Date(),
         repo: repo,
         reviewDecision: .noReview,
-        checkStatus: .noChecks
+        checkStatus: .noChecks,
+        assignees: assignees
     )
 }
 
@@ -314,6 +315,65 @@ final class AppModelTests: XCTestCase {
         }
         XCTAssertEqual(groups.first?.repo, repoB, "Repo B should be first after move")
         XCTAssertEqual(fetcher.batchCallCount, callsBefore, "moveRepo must not trigger a fetch")
+    }
+
+    // MARK: - Assigned-to-me filter
+
+    func testFilterOffShowsAllPRs() async {
+        let repo = makeRepo()
+        store.add(repo)
+        let pr1 = makePR(id: "pr1", repo: repo, assignees: [UserRef(login: "test-user", avatarURL: nil)])
+        let pr2 = makePR(id: "pr2", repo: repo, assignees: [])
+        fetcher.batchResult = .success(batchResult(repo: repo, prs: [pr1, pr2]))
+        model.viewer = Viewer(login: "test-user", avatarUrl: URL(string: "https://example.com/a.png")!)
+        model.showOnlyAssignedToMe = false
+
+        await model.performRefresh()
+
+        XCTAssertEqual(model.filteredGroups.first?.pullRequests.count, 2)
+    }
+
+    func testFilterOnRetainsOnlyMatchingPRs() async {
+        let repo = makeRepo()
+        store.add(repo)
+        let pr1 = makePR(id: "pr1", repo: repo, assignees: [UserRef(login: "test-user", avatarURL: nil)])
+        let pr2 = makePR(id: "pr2", repo: repo, assignees: [UserRef(login: "other-user", avatarURL: nil)])
+        fetcher.batchResult = .success(batchResult(repo: repo, prs: [pr1, pr2]))
+        model.viewer = Viewer(login: "test-user", avatarUrl: URL(string: "https://example.com/a.png")!)
+
+        await model.performRefresh()
+        model.showOnlyAssignedToMe = true
+
+        let groups = model.filteredGroups
+        XCTAssertEqual(groups.first?.pullRequests.count, 1)
+        XCTAssertEqual(groups.first?.pullRequests.first?.id, "pr1")
+    }
+
+    func testFilterOnWithNoViewerShowsAllPRs() async {
+        let repo = makeRepo()
+        store.add(repo)
+        let pr = makePR(id: "pr1", repo: repo, assignees: [UserRef(login: "someone", avatarURL: nil)])
+        fetcher.batchResult = .success(batchResult(repo: repo, prs: [pr]))
+        model.viewer = nil
+
+        await model.performRefresh()
+        model.showOnlyAssignedToMe = true
+
+        XCTAssertEqual(model.filteredGroups.first?.pullRequests.count, 1)
+    }
+
+    func testFilterUpdatesTotalCount() async {
+        let repo = makeRepo()
+        store.add(repo)
+        let pr1 = makePR(id: "pr1", repo: repo, assignees: [UserRef(login: "test-user", avatarURL: nil)])
+        let pr2 = makePR(id: "pr2", repo: repo, assignees: [])
+        fetcher.batchResult = .success(batchResult(repo: repo, prs: [pr1, pr2]))
+        model.viewer = Viewer(login: "test-user", avatarUrl: URL(string: "https://example.com/a.png")!)
+
+        await model.performRefresh()
+        model.showOnlyAssignedToMe = true
+
+        XCTAssertEqual(model.filteredGroups.first?.totalCount, 1)
     }
 
     // MARK: - refreshSingleRepo

--- a/Tests/GowiTests/NotificationServiceTests.swift
+++ b/Tests/GowiTests/NotificationServiceTests.swift
@@ -28,7 +28,8 @@ private func makePR(id: String, repo: TrackedRepo) -> PullRequest {
         updatedAt: Date(),
         repo: repo,
         reviewDecision: .noReview,
-        checkStatus: .noChecks
+        checkStatus: .noChecks,
+        assignees: []
     )
 }
 


### PR DESCRIPTION
Closes #51

## Summary

- `UserRef` struct (`login`, `avatarURL`) added to the domain model; `PullRequest` gains an `assignees: [UserRef]` field
- GraphQL fragments updated in both the single-repo query and the batch query to fetch `assignees(first: 5)`
- `PRRow` renders up to 3 assignee avatars (16 pt circles) after the author avatar, separated by a thin vertical divider, with a `+N` overflow label when there are 4 or more assignees
- `AppModel.showOnlyAssignedToMe` (non-persisted, resets to `false` on launch) drives a `filteredGroups` computed property; when the toggle is on and a viewer is known, each group's PR list is narrowed to PRs where the viewer is an assignee
- Toolbar toggle (`person.fill`) wired up in both `MainWindow` and the `MenuBarRoot` header; `MenuBarRoot.totalCount` and `PRListView` reflect the filtered result while `MenuBarLabel` (the menu bar icon badge) continues to show the raw total

## Test plan

- [x] Build succeeds (`xcodebuild build`)
- [x] Full test suite passes (`xcodebuild test`) — 4 new filter tests added to `AppModelTests`
  - `testFilterOffShowsAllPRs`
  - `testFilterOnRetainsOnlyMatchingPRs`
  - `testFilterOnWithNoViewerShowsAllPRs`
  - `testFilterUpdatesTotalCount`
- [ ] Launch the app, add a repo, verify assignee avatars appear in PR rows
- [ ] Toggle "assigned to me" in the main window toolbar and menu bar popover; verify filter applies correctly
- [ ] Confirm filter state resets to off after quitting and relaunching

🤖 Generated with [Claude Code](https://claude.com/claude-code)