### PR TITLE
ui: simplify and dedupe UI helpers

### DIFF
--- a/Sources/Gowi/AppModel.swift
+++ b/Sources/Gowi/AppModel.swift
@@ -7,6 +7,13 @@ enum PRState {
     case loading
     case loaded([RepoGroup])
     case error(String)
+
+    var totalOpenPRs: Int {
+        if case .loaded(let groups) = self {
+            return groups.reduce(0) { $0 + $1.totalCount }
+        }
+        return 0
+    }
 }
 
 struct RepoGroup: Identifiable, Hashable, Codable {
@@ -109,6 +116,20 @@ final class AppModel: ObservableObject {
         } catch {
             lastError = error.localizedDescription
         }
+    }
+
+    // MARK: - last-seen marker
+
+    static let lastSeenAtKey = "lastSeenAt"
+
+    /// Update the "last seen" timestamp consumed by `PRRow` to flag new PRs.
+    /// Debounced: many `didBecomeKey` notifications can fire per second across
+    /// windows, and every write would invalidate the @AppStorage of every row.
+    func markPRsSeen() {
+        let defaults = UserDefaults.standard
+        let now = Date().timeIntervalSince1970
+        guard now - defaults.double(forKey: Self.lastSeenAtKey) > 1 else { return }
+        defaults.set(now, forKey: Self.lastSeenAtKey)
     }
 
     // MARK: - PR refresh

--- a/Sources/Gowi/Config.swift
+++ b/Sources/Gowi/Config.swift
@@ -27,4 +27,7 @@ enum Config {
     /// GitHub token settings page — fallback destination when a SAML auth URL
     /// isn't available from response headers.
     static let tokenSettingsURL = URL(string: "https://github.com/settings/tokens")!
+
+    /// Window scene id for the primary `WindowGroup`. Referenced by `openWindow(id:)`.
+    static let mainWindowID = "main"
 }

--- a/Sources/Gowi/GowiApp.swift
+++ b/Sources/Gowi/GowiApp.swift
@@ -35,7 +35,7 @@ struct GowiApp: App {
     }
 
     var body: some Scene {
-        WindowGroup("gowi", id: "main") {
+        WindowGroup("gowi", id: Config.mainWindowID) {
             MainWindow()
                 .environmentObject(model)
                 .environmentObject(auth)

--- a/Sources/Gowi/UI/AccessibilityID.swift
+++ b/Sources/Gowi/UI/AccessibilityID.swift
@@ -30,4 +30,9 @@ enum AccessibilityID {
         static func errorRow(_ repoID: String) -> String { "prRow.error.\(repoID)" }
         static func errorRetry(_ repoID: String) -> String { "prRow.error.\(repoID).retry" }
     }
+
+    enum Repositories {
+        static let exportButton = "exportReposButton"
+        static let importButton = "importReposButton"
+    }
 }

--- a/Sources/Gowi/UI/MainWindow.swift
+++ b/Sources/Gowi/UI/MainWindow.swift
@@ -13,15 +13,15 @@ struct MainWindow: View {
                 .navigationTitle(windowTitle)
                 .toolbar { toolbarContent }
         }
-        .onAppear { markSeen() }
+        .onAppear { model.markPRsSeen() }
         .onReceive(NotificationCenter.default.publisher(for: NSWindow.didBecomeKeyNotification)) { _ in
-            markSeen()
+            model.markPRsSeen()
         }
     }
 
     private var windowTitle: String {
         guard auth.state == .signedIn else { return "gowi" }
-        let total = totalPRs(groups)
+        let total = model.state.totalOpenPRs
         return total > 0 ? "\(total) open" : "gowi"
     }
 
@@ -53,7 +53,7 @@ struct MainWindow: View {
                         .accessibilityIdentifier(AccessibilityID.Main.loading)
                 case .loaded(let groups):
                     let hasErrors = groups.contains { $0.error != nil }
-                    if !hasErrors && (groups.isEmpty || totalPRs(groups) == 0) {
+                    if !hasErrors && (groups.isEmpty || model.state.totalOpenPRs == 0) {
                         allClearState
                     } else {
                         PRListView(
@@ -118,8 +118,6 @@ struct MainWindow: View {
             dismissID: AccessibilityID.Banner.tokenRevokedDismiss
         )
     }
-
-    // MARK: - cached data banner
 
     private var cachedDataBanner: some View {
         HStack(spacing: 8) {
@@ -187,7 +185,7 @@ struct MainWindow: View {
                 Button(action.label, action: action.handler)
                     .buttonStyle(.borderedProminent)
                     .controlSize(.small)
-                    .accessibilityIdentifier(actionID ?? "")
+                    .accessibilityIdentifier(ifPresent: actionID)
             }
             Button { onDismiss() } label: {
                 Image(systemName: "xmark")
@@ -196,7 +194,7 @@ struct MainWindow: View {
             .buttonStyle(.plain)
             .foregroundStyle(.secondary)
             .help("Dismiss")
-            .accessibilityIdentifier(dismissID ?? "")
+            .accessibilityIdentifier(ifPresent: dismissID)
         }
         .padding(.horizontal, 12)
         .padding(.vertical, 8)
@@ -205,7 +203,7 @@ struct MainWindow: View {
             Divider()
         }
         .accessibilityElement(children: .contain)
-        .accessibilityIdentifier(rootID ?? "")
+        .accessibilityIdentifier(ifPresent: rootID)
     }
 
     // MARK: - states
@@ -269,19 +267,11 @@ struct MainWindow: View {
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier(AccessibilityID.Main.errorState)
     }
+}
 
-    // MARK: - helpers
-
-    private var groups: [RepoGroup] {
-        if case .loaded(let g) = model.state { return g }
-        return []
-    }
-
-    private func totalPRs(_ groups: [RepoGroup]) -> Int {
-        groups.reduce(0) { $0 + $1.totalCount }
-    }
-
-    private func markSeen() {
-        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "lastSeenAt")
+private extension View {
+    @ViewBuilder
+    func accessibilityIdentifier(ifPresent id: String?) -> some View {
+        if let id { self.accessibilityIdentifier(id) } else { self }
     }
 }

--- a/Sources/Gowi/UI/MenuBarRoot.swift
+++ b/Sources/Gowi/UI/MenuBarRoot.swift
@@ -9,17 +9,11 @@ struct MenuBarLabel: View {
     var body: some View {
         HStack(spacing: 3) {
             Image(systemName: "arrow.triangle.branch")
-            if totalCount > 0 {
-                Text("\(totalCount)").monospacedDigit()
+            let count = model.state.totalOpenPRs
+            if count > 0 {
+                Text("\(count)").monospacedDigit()
             }
         }
-    }
-
-    private var totalCount: Int {
-        if case .loaded(let groups) = model.state {
-            return groups.reduce(0) { $0 + $1.totalCount }
-        }
-        return 0
     }
 }
 
@@ -41,14 +35,14 @@ struct MenuBarRoot: View {
             footer
         }
         .frame(width: 420, height: 560)
-        .onAppear { markSeen() }
+        .onAppear { model.markPRsSeen() }
     }
 
     // MARK: - sections
 
     private var header: some View {
         HStack(spacing: 8) {
-            Text("\(totalCount) open")
+            Text("\(model.state.totalOpenPRs) open")
                 .font(.headline)
                 .monospacedDigit()
             Spacer()
@@ -96,7 +90,7 @@ struct MenuBarRoot: View {
             case .signedOut, .loading:
                 ProgressView().frame(maxWidth: .infinity, maxHeight: .infinity)
             case .loaded(let groups):
-                if totalCount == 0 {
+                if model.state.totalOpenPRs == 0 {
                     centred {
                         Image(systemName: "checkmark.seal")
                             .font(.largeTitle).foregroundStyle(.green)
@@ -182,19 +176,8 @@ struct MenuBarRoot: View {
         .padding()
     }
 
-    private var totalCount: Int {
-        if case .loaded(let groups) = model.state {
-            return groups.reduce(0) { $0 + $1.totalCount }
-        }
-        return 0
-    }
-
     private func openMainWindow() {
-        openWindow(id: "main")
+        openWindow(id: Config.mainWindowID)
         NSApp.activate(ignoringOtherApps: true)
-    }
-
-    private func markSeen() {
-        UserDefaults.standard.set(Date().timeIntervalSince1970, forKey: "lastSeenAt")
     }
 }

--- a/Sources/Gowi/UI/PRListView.swift
+++ b/Sources/Gowi/UI/PRListView.swift
@@ -48,6 +48,7 @@ struct PRListView: View {
     }
 
     private static let childRowInsets = EdgeInsets(top: 2, leading: -20, bottom: 2, trailing: 4)
+    private static let placeholderRowInsets = EdgeInsets(top: 2, leading: 16, bottom: 2, trailing: 16)
 
     @ViewBuilder
     private func body(for group: RepoGroup) -> some View {
@@ -58,7 +59,7 @@ struct PRListView: View {
             Text("No open PRs")
                 .font(.callout)
                 .foregroundStyle(.secondary)
-                .listRowInsets(EdgeInsets(top: 2, leading: 16, bottom: 2, trailing: 16))
+                .listRowInsets(Self.placeholderRowInsets)
         } else {
             ForEach(group.pullRequests) { pr in
                 PRRow(pr: pr)

--- a/Sources/Gowi/UI/PRRow.swift
+++ b/Sources/Gowi/UI/PRRow.swift
@@ -4,6 +4,7 @@ import AppKit
 struct PRRow: View {
     let pr: PullRequest
     @State private var hovering = false
+    // @AppStorage requires a string literal — keep in sync with `AppModel.lastSeenAtKey`.
     @AppStorage("lastSeenAt") private var lastSeenAtTimestamp: Double = 0
 
     private var isNew: Bool {
@@ -95,6 +96,10 @@ struct PRRow: View {
     }()
 }
 
+private struct StatusIconPlaceholder: View {
+    var body: some View { Color.clear.frame(width: 16, height: 16) }
+}
+
 struct ReviewIcon: View {
     let decision: ReviewDecision
     var body: some View {
@@ -112,10 +117,9 @@ struct ReviewIcon: View {
                 .foregroundStyle(.secondary)
                 .help("Review required")
         case .noReview:
-            placeholder
+            StatusIconPlaceholder()
         }
     }
-    private var placeholder: some View { Color.clear.frame(width: 16, height: 16) }
 }
 
 struct CheckIcon: View {
@@ -135,8 +139,7 @@ struct CheckIcon: View {
                 .foregroundStyle(.yellow)
                 .help("Checks pending")
         case .noChecks:
-            placeholder
+            StatusIconPlaceholder()
         }
     }
-    private var placeholder: some View { Color.clear.frame(width: 16, height: 16) }
 }

--- a/Sources/Gowi/UI/RepositoriesPane.swift
+++ b/Sources/Gowi/UI/RepositoriesPane.swift
@@ -62,14 +62,14 @@ struct RepositoriesPane: View {
                 }
                 .disabled(store.repos.isEmpty)
                 .help("Export repositories to the clipboard")
-                .accessibilityIdentifier("exportReposButton")
+                .accessibilityIdentifier(AccessibilityID.Repositories.exportButton)
                 .accessibilityHint(store.repos.isEmpty ? "Requires at least one tracked repository." : "Copies tracked repositories to the clipboard.")
 
                 Button("Import Repositories") {
                     importRepos()
                 }
                 .help("Import repositories from the clipboard")
-                .accessibilityIdentifier("importReposButton")
+                .accessibilityIdentifier(AccessibilityID.Repositories.importButton)
 
                 Text(trackedCountLabel)
                     .font(.caption)
@@ -183,18 +183,19 @@ private struct NotifyToggle: View {
     let repo: TrackedRepo
 
     var body: some View {
+        let on = notifications.isEnabled(repo)
         let isOn = Binding<Bool>(
-            get: { notifications.isEnabled(repo) },
+            get: { on },
             set: { newValue in
                 Task { await notifications.setEnabled(newValue, for: repo) }
             }
         )
         Toggle(isOn: isOn) {
-            Image(systemName: notifications.isEnabled(repo) ? "bell.fill" : "bell.slash")
+            Image(systemName: on ? "bell.fill" : "bell.slash")
         }
         .toggleStyle(.button)
         .buttonStyle(.borderless)
-        .help(notifications.isEnabled(repo) ? "Notifications on for this repo" : "Notify on new PRs")
+        .help(on ? "Notifications on for this repo" : "Notify on new PRs")
     }
 }
 


### PR DESCRIPTION
## Summary

Cleanup pass over `Sources/Gowi/UI/` driven by three parallel review agents (reuse, quality, efficiency). Behaviour-preserving — covered by existing unit + UI tests.

- **Dedupe `totalOpenPRs`** — single computed property on `PRState` replaces three near-identical `if case .loaded { reduce(...) }` blocks in `MenuBarLabel`, `MenuBarRoot`, and `MainWindow`.
- **Centralise `lastSeenAt`** — `AppModel.markPRsSeen()` replaces two duplicate `markSeen()` helpers, and adds a 1-second debounce. Without the debounce, every `NSWindow.didBecomeKeyNotification` (including Settings, the menu-bar popover host, etc.) wrote `lastSeenAt` and invalidated every `PRRow`'s `@AppStorage`, re-rendering the entire list on each window focus change.
- **`Config.mainWindowID`** replaces the `"main"` string literal in `GowiApp` (`WindowGroup` id) and `MenuBarRoot` (`openWindow(id:)`).
- **`AccessibilityID.Repositories`** adds enum entries for the export/import buttons that previously used inline literals while every other UI used the enum.
- **`accessibilityIdentifier(ifPresent:)`** small View extension fixes the empty-string sentinels in `MainWindow.inlineBanner` (`actionID ?? ""`).
- Misc: hoisted `placeholderRowInsets` constant in `PRListView`, cached `notifications.isEnabled(repo)` once in `NotifyToggle`, extracted `StatusIconPlaceholder` to dedupe the identical placeholder in `ReviewIcon` and `CheckIcon`, removed a redundant `// MARK:` line.

Net diff: +64 / -57.

## Test plan

- [x] `xcodebuild -scheme gowi -destination 'platform=macOS' build` succeeds
- [x] `xcodebuild -scheme gowi -destination 'platform=macOS' test` — all unit + UI tests pass
- [ ] Smoke: launch app, observe menu bar count, open main window, verify "new PR" dot still appears for PRs newer than `lastSeenAt`
- [ ] Smoke: trigger SAML/token-revoked banners and verify Dismiss button works (covered by `inlineBanner` change)
- [ ] Smoke: export/import repos buttons in Settings → Repositories still work and have the expected accessibility ids

🤖 Generated with [Claude Code](https://claude.com/claude-code)